### PR TITLE
feature/command-refactor

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   testEnvironment: "node",
   transform: {
-    "^.+.tsx?$": ["ts-jest",{}],
+    "^.+.tsx?$": ["ts-jest", {}],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "dependencies": {
         "@nhost/nhost-js": "^3.1.10",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "discord.js": "^14.16.2",
         "graphql": "^16.9.0"
       },
@@ -2464,6 +2466,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@nhost/nhost-js": "^3.1.10",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "discord.js": "^14.16.2",
     "graphql": "^16.9.0"
   },

--- a/src/ExtendedClient.ts
+++ b/src/ExtendedClient.ts
@@ -1,15 +1,5 @@
-import {
-  Client,
-  ClientOptions,
-  Collection,
-  CommandInteraction,
-  SlashCommandBuilder,
-} from "discord.js";
-
-export interface Command {
-  data: SlashCommandBuilder;
-  execute: (interaction: CommandInteraction) => Promise<void>;
-}
+import { Client, ClientOptions, Collection } from "discord.js";
+import { Command } from "./commands/command";
 
 class ExtendedClient extends Client {
   commands: Collection<string, Command>;

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -1,0 +1,46 @@
+# Adding a command
+
+* Each command has its own file so create a new one in an intuitive place, create new directories if necessary
+* Each command must extend the Command class which provides some useful abstractions and methods to implement
+* in your constructor
+  * inject services you intend to use
+  * call the super constructor with your name, description and if your command is one that should only be used by admins
+  * add all the inputs necessary for your command by using the applicable Command methods or by adding new Command methods where necessary
+* in your run method you must reply within 3 seconds so discord doesn't trash your interaction
+  * if you're doing async work you should reply with a generic message saying "working on your request" or something of the like
+
+example: 
+```
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
+
+export class NameOfYourCommand extends Command {
+  inputNames = {
+    user: "userinput",
+    string: "stringinput",
+    number: "numberinput",
+  };
+
+  constructor(private service: ServiceToInject) {
+    super("command-name", "command description", optionalIsAdminBoolean);
+    this.addUserInput(this.inputNames.user, "Input a user", optionalRequiredBoolean);
+    this.addStringInput(this.inputNames.string, "Input a string");
+    this.addNumberInput(
+      this.inputNames.number,
+      "Input a number",
+      true,
+    );
+  }
+
+  async run(interaction: CustomInteraction) {
+    const user: User = interaction.options.getUser(this.inputNames.user, includeBooleanHereIfInputWasRequired);
+    const numberInput: number | null = interaction.options.getNumber(this.inputNames.number);
+    const stringInput: string = interaction.options.getString(this.inputNames.string
+    
+    interaction.reply("Got your command, working on it!"
+    await this.service.someMethod()
+    interaction.editReply("useful information about the work that was executed")
+  }
+}
+
+```

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -1,6 +1,17 @@
-# Adding a command
+# Commands
+## How commands work
+
+* All commands are imported and instantiated in the command array in the index.ts file
+* That array is imported in 
+  * deploy-commands
+    * use ./deploy-commands to deploy the commands to discord so it can correctly prompt users for parameters
+  * the main entry file
+    * takes an event and executes the correct command 
+
+## Adding a command
 
 * Each command has its own file so create a new one in an intuitive place, create new directories if necessary
+* Add your command to the command array in src/commands/index.ts
 * Each command must extend the Command class which provides some useful abstractions and methods to implement
 * in your constructor
   * inject services you intend to use

--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -6,7 +6,7 @@
   * deploy-commands
     * use ./deploy-commands to deploy the commands to discord so it can correctly prompt users for parameters
   * the main entry file
-    * takes an event and executes the correct command 
+    * takes an event and executes the correct commands run method with the interaction discord recorded
 
 ## Adding a command
 

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -1,7 +1,7 @@
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
 import { PrioService } from "../../../services/prio";
-import { setEasternHours } from "../../../utility/utility";
+import { setEasternHours } from "../../../utility/time";
 
 export class AddPrioCommand extends Command {
   inputNames = {
@@ -64,7 +64,6 @@ export class AddPrioCommand extends Command {
     const prioReasonString = dbIds
       .map((dbId, index) => `${users[index]?.displayName} prio id: ${dbId}`)
       .join("; ");
-    console.log(user1, user2, user3, users);
     await interaction.reply(
       `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${this.formatDate(startDate)} to ${this.formatDate(endDate)} because ${reason}. ${prioReasonString}`,
     );

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -1,10 +1,10 @@
-import { prioService } from "../../../services";
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
 import { format } from "date-fns";
+import { PrioService } from "../../../services/prio";
 
 export class AddPrioCommand extends Command {
-  constructor() {
+  constructor(private prioService: PrioService) {
     super("addprio", "Adds a prio entry for up to three players", true);
 
     this.addUserInput("user1", "First user", true);
@@ -31,7 +31,7 @@ export class AddPrioCommand extends Command {
     const users = [user1, user2, user3].filter((user) => !!user);
     let dbIds: string[];
     try {
-      dbIds = await prioService.setPlayerPrio(
+      dbIds = await this.prioService.setPlayerPrio(
         users,
         startDate,
         endDate,

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -1,6 +1,7 @@
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
 import { PrioService } from "../../../services/prio";
+import { setEasternHours } from "../../../utility/utility";
 
 export class AddPrioCommand extends Command {
   inputNames = {
@@ -41,9 +42,9 @@ export class AddPrioCommand extends Command {
     const reason = interaction.options.getString(this.inputNames.reason, true);
     const startDate =
       interaction.options.getDate(this.inputNames.startDate) ?? new Date();
-    const endDate = interaction.options.getDate(this.inputNames.endDate, true);
+    let endDate = interaction.options.getDate(this.inputNames.endDate, true);
     // end date is inclusive
-    endDate?.setHours(23, 59, 59);
+    endDate = setEasternHours(endDate, 23, 59, 59);
 
     const users = [user1, user2, user3].filter((user) => !!user);
     let dbIds: string[];

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -1,6 +1,5 @@
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
-import { format } from "date-fns";
 import { PrioService } from "../../../services/prio";
 
 export class AddPrioCommand extends Command {
@@ -66,7 +65,7 @@ export class AddPrioCommand extends Command {
       .join("; ");
     console.log(user1, user2, user3, users);
     await interaction.reply(
-      `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${format(startDate, "M/dd hh:mm a")} to ${format(endDate, "M/dd hh:mm a")} because ${reason}. ${prioReasonString}`,
+      `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${this.formatDate(startDate)} to ${this.formatDate(endDate)} because ${reason}. ${prioReasonString}`,
     );
   }
 }

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -1,6 +1,7 @@
-import { ChatInputCommandInteraction } from "discord.js";
 import { prioService } from "../../../services";
-import { Command, parseDate } from "../../command";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
+import { format } from "date-fns";
 
 export class AddPrioCommand extends Command {
   constructor() {
@@ -17,31 +18,15 @@ export class AddPrioCommand extends Command {
     this.addStringInput("reason", "Reason fro prio", true);
   }
 
-  async run(interaction: ChatInputCommandInteraction) {
+  async run(interaction: CustomInteraction) {
     const user1 = interaction.options.getUser("user1", true);
     const user2 = interaction.options.getUser("user2");
     const user3 = interaction.options.getUser("user3");
     const amount = interaction.options.getNumber("amount", true);
     const reason = interaction.options.getString("reason", true);
-    const startDateString = interaction.options.getString("startDate");
-    const endDateString = interaction.options.getString("endDate", true);
-
-    let startDate = new Date();
-    try {
-      if (startDateString) {
-        startDate = parseDate(startDateString, "12 am");
-      }
-    } catch (e) {
-      await interaction.reply("Can't parse start date " + e);
-      return;
-    }
-    let endDate: Date;
-    try {
-      endDate = parseDate(endDateString, "11:59 pm");
-    } catch (e) {
-      await interaction.reply("Can't parse end date " + e);
-      return;
-    }
+    const startDate = interaction.options.getDate("startDate") ?? new Date();
+    const endDate = interaction.options.getDate("endDate", true);
+    endDate?.setHours(23, 59, 59);
 
     const users = [user1, user2, user3].filter((user) => !!user);
     let dbIds: string[];
@@ -63,7 +48,7 @@ export class AddPrioCommand extends Command {
       .join("; ");
     console.log(user1, user2, user3, users);
     await interaction.reply(
-      `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${startDateString} to ${endDateString} because ${reason}. ${prioReasonString}`,
+      `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${format(startDate, "M/dd hh:mm a")} to ${format(endDate, "M/dd hh:mm a")} because ${reason}. ${prioReasonString}`,
     );
   }
 }

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -4,28 +4,46 @@ import { format } from "date-fns";
 import { PrioService } from "../../../services/prio";
 
 export class AddPrioCommand extends Command {
+  inputNames = {
+    user1: "user1",
+    user2: "user2",
+    user3: "user3",
+    amount: "amount",
+    reason: "reason",
+    startDate: "startdate",
+    endDate: "enddate",
+  };
+
   constructor(private prioService: PrioService) {
     super("addprio", "Adds a prio entry for up to three players", true);
 
-    this.addUserInput("user1", "First user", true);
-    this.addUserInput("user2", "Second user");
-    this.addUserInput("user3", "Third user");
+    this.addUserInput(this.inputNames.user1, "First user", true);
+    this.addUserInput(this.inputNames.user2, "Second user");
+    this.addUserInput(this.inputNames.user3, "Third user");
     this.addNumberInput(
-      "amount",
+      this.inputNames.amount,
       "Amount of prio, negative for low prio",
       true,
     );
-    this.addStringInput("reason", "Reason fro prio", true);
+    this.addStringInput(this.inputNames.reason, "Reason fro prio", true);
+    this.addStringInput(
+      this.inputNames.startDate,
+      "Optional start date, defaults to when command is called",
+      true,
+    );
+    this.addStringInput(this.inputNames.endDate, "End date", true);
   }
 
   async run(interaction: CustomInteraction) {
-    const user1 = interaction.options.getUser("user1", true);
-    const user2 = interaction.options.getUser("user2");
-    const user3 = interaction.options.getUser("user3");
-    const amount = interaction.options.getNumber("amount", true);
-    const reason = interaction.options.getString("reason", true);
-    const startDate = interaction.options.getDate("startDate") ?? new Date();
-    const endDate = interaction.options.getDate("endDate", true);
+    const user1 = interaction.options.getUser(this.inputNames.user1, true);
+    const user2 = interaction.options.getUser(this.inputNames.user2);
+    const user3 = interaction.options.getUser(this.inputNames.user3);
+    const amount = interaction.options.getNumber(this.inputNames.amount, true);
+    const reason = interaction.options.getString(this.inputNames.reason, true);
+    const startDate =
+      interaction.options.getDate(this.inputNames.startDate) ?? new Date();
+    const endDate = interaction.options.getDate(this.inputNames.endDate, true);
+    // end date is inclusive
     endDate?.setHours(23, 59, 59);
 
     const users = [user1, user2, user3].filter((user) => !!user);

--- a/src/commands/admin/prio/expunge-prio.ts
+++ b/src/commands/admin/prio/expunge-prio.ts
@@ -26,7 +26,7 @@ module.exports = {
       );
       return;
     }
-    await prioService.expungePlayerPrio(interaction.member, [user.id]);
+    await prioService.expungePlayerPrio([user.id]);
     await interaction.reply(
       `User ${user.username} has been removed from the low priority list.`,
     );

--- a/src/commands/admin/prio/expunge-prio.ts
+++ b/src/commands/admin/prio/expunge-prio.ts
@@ -1,34 +1,19 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
-import { prioService } from "../../../services";
-import { isGuildMember } from "../../../utility/utility";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
 
 // TODO ask for reason and amount in command, change execute command to work correctly
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("expungeprio")
-    .setDescription("Removes a priority entry from the db")
-    .addUserOption((option) =>
-      option
-        .setName("prio-id")
-        .setDescription("Prio db id to be removed from priority table")
-        .setRequired(true),
-    ),
-
-  async execute(interaction: ChatInputCommandInteraction) {
-    const user = interaction.options.getUser("user");
-    if (!user) {
-      interaction.reply("User not found, no command executed");
-      return;
-    }
-    if (!isGuildMember(interaction.member)) {
-      interaction.reply(
-        "Can't find the member issuing the command or this is an api command, no command executed",
-      );
-      return;
-    }
-    await prioService.expungePlayerPrio([user.id]);
-    await interaction.reply(
-      `User ${user.username} has been removed from the low priority list.`,
+export class ExpungePrioCommand extends Command {
+  constructor() {
+    super("expungeprio", "Removes a priority entry from the db", true);
+    this.addNumberInput(
+      "prio-id",
+      "Prio db id to be removed from priority table",
+      true,
     );
-  },
-};
+  }
+
+  async run(interaction: CustomInteraction) {
+    // TODO implement
+    console.log(interaction);
+  }
+}

--- a/src/commands/admin/roles/add-admin-role.ts
+++ b/src/commands/admin/roles/add-admin-role.ts
@@ -1,32 +1,21 @@
-import {
-  SlashCommandBuilder,
-  PermissionFlagsBits,
-  ChatInputCommandInteraction,
-} from "discord.js";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("addadminrole") // Command name matching file name
-    .setDescription("Adds a role that can perform scrim admin actions")
-    .addRoleOption((option) =>
+export class AddAdminRoleCommand extends Command {
+  constructor() {
+    super("addadminrole", "Adds a role that can perform scrim admin actions");
+    this.addRoleOption((option) =>
       option.setName("role").setDescription("Role to add").setRequired(true),
-    )
-    // You will usually only want users that can create new channels to
-    // be able to use this command and this is what this line does.
-    // Feel free to remove it if you want to allow any users to
-    // create new channels
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
-    // It's impossible to create normal text channels inside DMs, so
-    // it's in your best interest in disabling this command through DMs
-    // as well. Threads, however, can be created in DMs, but we will see
-    // more about them later in this post
-    .setDMPermission(false),
-  async execute(interaction: ChatInputCommandInteraction) {
+    );
+  }
+
+  async run(interaction: CustomInteraction) {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
     await interaction.reply({
       content: "Fetched all input and working on your request!",
     });
-  },
-};
+    // TODO implement
+  }
+}

--- a/src/commands/admin/roles/add-admin-role.ts
+++ b/src/commands/admin/roles/add-admin-role.ts
@@ -4,9 +4,7 @@ import { CustomInteraction } from "../../interaction";
 export class AddAdminRoleCommand extends Command {
   constructor() {
     super("addadminrole", "Adds a role that can perform scrim admin actions");
-    this.addRoleOption((option) =>
-      option.setName("role").setDescription("Role to add").setRequired(true),
-    );
+    this.addRoleInput("role", "Role to add", true);
   }
 
   async run(interaction: CustomInteraction) {

--- a/src/commands/admin/roles/remove-admin-role.ts
+++ b/src/commands/admin/roles/remove-admin-role.ts
@@ -7,9 +7,7 @@ export class RemoveAdminRoleCommand extends Command {
       "removeadminrole",
       "Removes a role from performing scrim admin actions",
     );
-    this.addRoleOption((option) =>
-      option.setName("role").setDescription("Role to add").setRequired(true),
-    );
+    this.addRoleInput("role", "Role to remove", true);
   }
 
   async run(interaction: CustomInteraction) {

--- a/src/commands/admin/roles/remove-admin-role.ts
+++ b/src/commands/admin/roles/remove-admin-role.ts
@@ -1,32 +1,24 @@
-import {
-  SlashCommandBuilder,
-  PermissionFlagsBits,
-  ChatInputCommandInteraction,
-} from "discord.js";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("removeadminrole") // Command name matching file name
-    .setDescription("Removes a role that can perform scrim admin actions")
-    .addRoleOption((option) =>
+export class RemoveAdminRoleCommand extends Command {
+  constructor() {
+    super(
+      "removeadminrole",
+      "Removes a role from performing scrim admin actions",
+    );
+    this.addRoleOption((option) =>
       option.setName("role").setDescription("Role to add").setRequired(true),
-    )
-    // You will usually only want users that can create new channels to
-    // be able to use this command and this is what this line does.
-    // Feel free to remove it if you want to allow any users to
-    // create new channels
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
-    // It's impossible to create normal text channels inside DMs, so
-    // it's in your best interest in disabling this command through DMs
-    // as well. Threads, however, can be created in DMs, but we will see
-    // more about them later in this post
-    .setDMPermission(false),
-  async execute(interaction: ChatInputCommandInteraction) {
+    );
+  }
+
+  async run(interaction: CustomInteraction) {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
     await interaction.reply({
       content: "Fetched all input and working on your request!",
     });
-  },
-};
+    // TODO implement
+  }
+}

--- a/src/commands/admin/scrim-crud/close-scrim.ts
+++ b/src/commands/admin/scrim-crud/close-scrim.ts
@@ -1,25 +1,13 @@
-import {
-  SlashCommandBuilder,
-  PermissionFlagsBits,
-  ChatInputCommandInteraction,
-} from "discord.js";
 import { signupsService } from "../../../services";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("createscrimsignup") // Command name matching file name
-    .setDescription("Creates a new scrim signup text channel")
-    // You will usually only want users that can create new channels to
-    // be able to use this command and this is what this line does.
-    // Feel free to remove it if you want to allow any users to
-    // create new channels
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
-    // It's impossible to create normal text channels inside DMs, so
-    // it's in your best interest in disabling this command through DMs
-    // as well. Threads, however, can be created in DMs, but we will see
-    // more about them later in this post
-    .setDMPermission(false),
-  async execute(interaction: ChatInputCommandInteraction) {
+export class CloseScrimCommand extends Command {
+  constructor() {
+    super("close-scrim", "Creates a new scrim signup text channel", true);
+  }
+
+  async run(interaction: CustomInteraction) {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
@@ -31,5 +19,5 @@ module.exports = {
     await signupsService.closeScrim(channelId);
 
     // TODO after closing the scrim delete the channel
-  },
-};
+  }
+}

--- a/src/commands/admin/scrim-crud/close-scrim.ts
+++ b/src/commands/admin/scrim-crud/close-scrim.ts
@@ -1,9 +1,9 @@
-import { signupsService } from "../../../services";
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
+import { ScrimSignups } from "../../../services/signups";
 
 export class CloseScrimCommand extends Command {
-  constructor() {
+  constructor(private signupService: ScrimSignups) {
     super("close-scrim", "Creates a new scrim signup text channel", true);
   }
 
@@ -16,7 +16,7 @@ export class CloseScrimCommand extends Command {
     });
     const channelId = interaction.channelId;
 
-    await signupsService.closeScrim(channelId);
+    await this.signupService.closeScrim(channelId);
 
     // TODO after closing the scrim delete the channel
   }

--- a/src/commands/admin/scrim-crud/compute-scrim.ts
+++ b/src/commands/admin/scrim-crud/compute-scrim.ts
@@ -1,38 +1,21 @@
-import {
-  SlashCommandBuilder,
-  PermissionFlagsBits,
-  ChatInputCommandInteraction,
-} from "discord.js";
 import { signupsService } from "../../../services";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("createscrimsignup") // Command name matching file name
-    .setDescription("Creates a new scrim signup text channel")
-    .addStringOption((option) =>
-      option
-        .setName("overstat-link")
-        .setDescription(
-          "Full length url of the completed scrim (not short url)",
-        )
-        .setMinLength(20)
-        .setMaxLength(150)
-        .setRequired(true),
-    )
-    .addNumberOption((option) =>
-      option.setName("skill").setDescription("Skill level of the lobby"),
-    )
-    // You will usually only want users that can create new channels to
-    // be able to use this command and this is what this line does.
-    // Feel free to remove it if you want to allow any users to
-    // create new channels
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
-    // It's impossible to create normal text channels inside DMs, so
-    // it's in your best interest in disabling this command through DMs
-    // as well. Threads, however, can be created in DMs, but we will see
-    // more about them later in this post
-    .setDMPermission(false),
-  async execute(interaction: ChatInputCommandInteraction) {
+export class ComputeScrimCommand extends Command {
+  constructor() {
+    super("compute-scrim", "Creates a new scrim signup text channel", true);
+    this.addStringInput(
+      "overstat-link",
+      "Full length url of the completed scrim (not short url)",
+      true,
+    );
+    // .setMinLength(20)
+    // .setMaxLength(150)
+    this.addNumberInput("skill", "Skill level of the lobby");
+  }
+
+  async run(interaction: CustomInteraction) {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
@@ -52,5 +35,5 @@ module.exports = {
     await interaction.reply(
       "Scrim successfully computed, you can now compute another lobby or close the scrim",
     );
-  },
-};
+  }
+}

--- a/src/commands/admin/scrim-crud/compute-scrim.ts
+++ b/src/commands/admin/scrim-crud/compute-scrim.ts
@@ -1,9 +1,9 @@
-import { signupsService } from "../../../services";
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
+import { ScrimSignups } from "../../../services/signups";
 
 export class ComputeScrimCommand extends Command {
-  constructor() {
+  constructor(private signupService: ScrimSignups) {
     super("compute-scrim", "Creates a new scrim signup text channel", true);
     this.addStringInput(
       "overstat-link",
@@ -27,7 +27,7 @@ export class ComputeScrimCommand extends Command {
     const skill = interaction.options.getNumber("skill", true);
 
     try {
-      await signupsService.computeScrim(channelId, overstatLink, skill);
+      await this.signupService.computeScrim(channelId, overstatLink, skill);
     } catch (error) {
       await interaction.reply(`Unable to complete request: ${error}`);
     }

--- a/src/commands/admin/scrim-crud/create-scrim.ts
+++ b/src/commands/admin/scrim-crud/create-scrim.ts
@@ -1,60 +1,19 @@
-// Importing SlashCommandBuilder is required for every slash command
-// We import PermissionFlagsBits so we can restrict this command usage
-// We also import ChannelType to define what kind of channel we are creating
-import {
-  SlashCommandBuilder,
-  PermissionFlagsBits,
-  ChannelType,
-  ChatInputCommandInteraction,
-  CategoryChannel,
-  SlashCommandStringOption,
-  TextChannel,
-} from "discord.js";
+import { ChannelType, CategoryChannel, TextChannel } from "discord.js";
 import { signupsService } from "../../../services";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("createscrimsignup") // Command name matching file name
-    .setDescription("Creates a new scrim signup text channel")
-    // Text channel name
-    .addStringOption((option: SlashCommandStringOption) =>
-      option
-        .setName("scrimdate") // option names need to always be lowercase and have no spaces
-        .setDescription("Choose date of the scrim")
-        .setMinLength(3) // A text channel needs to be named
-        .setMaxLength(5) // Discord will cut-off names past the 25 characters,
-        // so that's a good hard limit to set. You can manually increase this if you wish
-        .setRequired(true),
-    )
-    .addStringOption((option: SlashCommandStringOption) =>
-      option
-        .setName("scrimtime") // option names need to always be lowercase and have no spaces
-        .setDescription("Choose the time of the scrim")
-        .setMinLength(3) // A text channel needs to be named
-        .setMaxLength(4) // Discord will cut-off names past the 25 characters,
-        // so that's a good hard limit to set. You can manually increase this if you wish
-        .setRequired(true),
-    )
-    .addStringOption((option: SlashCommandStringOption) =>
-      option
-        .setName("scrimtype") // option names need to always be lowercase and have no spaces
-        .setDescription("Choose the type of scrim")
-        .setMinLength(1) // A text channel needs to be named
-        .setMaxLength(25) // Discord will cut-off names past the 25 characters,
-        // so that's a good hard limit to set. You can manually increase this if you wish
-        .setRequired(true),
-    )
-    // You will usually only want users that can create new channels to
-    // be able to use this command and this is what this line does.
-    // Feel free to remove it if you want to allow any users to
-    // create new channels
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
-    // It's impossible to create normal text channels inside DMs, so
-    // it's in your best interest in disabling this command through DMs
-    // as well. Threads, however, can be created in DMs, but we will see
-    // more about them later in this post
-    .setDMPermission(false),
-  async execute(interaction: ChatInputCommandInteraction) {
+export class CreateScrimCommand extends Command {
+  constructor() {
+    super("create-scrim", "Creates a new scrim signup text channel", true);
+    this.addStringInput("scrimdate", "Choose date of the scrim");
+    // .setMinLength(3) // A text channel needs to be named
+    // .setMaxLength(5)
+    this.addStringInput("time", "Choose the time of the scrim", true);
+    // .setMinLength(3) // A text channel needs to be named
+    // .setMaxLength(4) // Discord will cut-off names past the 25 characters,
+  }
+  async run(interaction: CustomInteraction) {
     /*
        TODO change variable names for date, time, type
        can we change so discord only accepts date times?
@@ -149,5 +108,5 @@ module.exports = {
         "Your channel could not be created! Please check if the bot has the necessary permissions!",
       );
     }
-  },
-};
+  }
+}

--- a/src/commands/admin/scrim-crud/create-scrim.ts
+++ b/src/commands/admin/scrim-crud/create-scrim.ts
@@ -1,10 +1,10 @@
 import { ChannelType, CategoryChannel, TextChannel } from "discord.js";
-import { signupsService } from "../../../services";
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
+import { ScrimSignups } from "../../../services/signups";
 
 export class CreateScrimCommand extends Command {
-  constructor() {
+  constructor(private signupService: ScrimSignups) {
     super("create-scrim", "Creates a new scrim signup text channel", true);
     this.addStringInput("scrimdate", "Choose date of the scrim");
     // .setMinLength(3) // A text channel needs to be named
@@ -81,7 +81,7 @@ export class CreateScrimCommand extends Command {
       if (channelId) {
         const dateTime = `${channelDate} - ${channelTime}`;
         const scrimDate = new Date(dateTime);
-        signupsService.createScrim(channelId, scrimDate);
+        await this.signupService.createScrim(channelId, scrimDate);
         const channel: TextChannel =
           (await interaction.client.channels.cache.get(
             channelId,

--- a/src/commands/admin/scrim-crud/get-signups.ts
+++ b/src/commands/admin/scrim-crud/get-signups.ts
@@ -1,10 +1,10 @@
-import { signupsService } from "../../../services";
 import { ScrimSignup } from "../../../models/Scrims";
 import { Command } from "../../command";
 import { CustomInteraction } from "../../interaction";
+import { ScrimSignups } from "../../../services/signups";
 
 export class GetSignupsCommand extends Command {
-  constructor() {
+  constructor(private signupService: ScrimSignups) {
     super("get-signups", "Creates a new scrim signup text channel", true);
   }
 
@@ -18,7 +18,7 @@ export class GetSignupsCommand extends Command {
 
     let channelSignups: { mainList: ScrimSignup[]; waitList: ScrimSignup[] };
     try {
-      channelSignups = await signupsService.getSignups(channelId);
+      channelSignups = await this.signupService.getSignups(channelId);
     } catch (e) {
       await interaction.reply(`Could not fetch signups ${e}`);
       return;

--- a/src/commands/admin/scrim-crud/get-signups.ts
+++ b/src/commands/admin/scrim-crud/get-signups.ts
@@ -1,26 +1,14 @@
-import {
-  SlashCommandBuilder,
-  PermissionFlagsBits,
-  ChatInputCommandInteraction,
-} from "discord.js";
 import { signupsService } from "../../../services";
 import { ScrimSignup } from "../../../models/Scrims";
+import { Command } from "../../command";
+import { CustomInteraction } from "../../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("get-signups") // Command name matching file name
-    .setDescription("Creates a new scrim signup text channel")
-    // You will usually only want users that can create new channels to
-    // be able to use this command and this is what this line does.
-    // Feel free to remove it if you want to allow any users to
-    // create new channels
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
-    // It's impossible to create normal text channels inside DMs, so
-    // it's in your best interest in disabling this command through DMs
-    // as well. Threads, however, can be created in DMs, but we will see
-    // more about them later in this post
-    .setDMPermission(false),
-  async execute(interaction: ChatInputCommandInteraction) {
+export class GetSignupsCommand extends Command {
+  constructor() {
+    super("get-signups", "Creates a new scrim signup text channel", true);
+  }
+
+  async run(interaction: CustomInteraction) {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
@@ -73,5 +61,5 @@ module.exports = {
 
     await interaction.reply({ content: messages.shift()!, ephemeral: true });
     await sendMessages(messages);
-  },
-};
+  }
+}

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -43,6 +43,19 @@ export abstract class Command extends SlashCommandBuilder {
     );
   }
 
+  addRoleInput(name: string, description: string, isRequired: boolean = false) {
+    this.addRoleOption((option) =>
+      option.setName(name).setDescription(description).setRequired(isRequired),
+    );
+  }
+
+  // at some point discord might actually implement this, for now just use string
+  addDateInput(name: string, description: string, isRequired: boolean = false) {
+    this.addStringOption((option) =>
+      option.setName(name).setDescription(description).setRequired(isRequired),
+    );
+  }
+
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
     if (this.isAdmin) {
       if (!isGuildMember(interaction.member)) {

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,0 +1,134 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { isGuildMember } from "../utility/utility";
+import { authService } from "../services";
+
+export abstract class Command extends SlashCommandBuilder {
+  isAdmin: boolean;
+
+  protected constructor(
+    name: string,
+    description: string,
+    isAdmin: boolean = false,
+  ) {
+    super();
+    this.setName(name);
+    this.setDescription(description);
+    this.isAdmin = isAdmin ?? false;
+  }
+
+  addUserInput(name: string, description: string, isRequired: boolean = false) {
+    this.addUserOption((option) =>
+      option.setName(name).setDescription(description).setRequired(isRequired),
+    );
+  }
+
+  addStringInput(
+    name: string,
+    description: string,
+    isRequired: boolean = false,
+  ) {
+    this.addStringOption((option) =>
+      option.setName(name).setDescription(description).setRequired(isRequired),
+    );
+  }
+
+  addNumberInput(
+    name: string,
+    description: string,
+    isRequired: boolean = false,
+  ) {
+    this.addNumberOption((option) =>
+      option.setName(name).setDescription(description).setRequired(isRequired),
+    );
+  }
+
+  async execute(interaction: ChatInputCommandInteraction): Promise<void> {
+    if (this.isAdmin) {
+      if (!isGuildMember(interaction.member)) {
+        await interaction.reply(
+          "Can't find the member issuing the command or this is an api command, no command executed",
+        );
+        return;
+      } else if (!(await authService.memberIsAdmin(interaction.member))) {
+        await interaction.reply("User calling command is not authorized");
+        return;
+      }
+    }
+    return this.run(interaction);
+  }
+
+  abstract run(interaction: ChatInputCommandInteraction): Promise<void>;
+}
+
+export const parseDate = (monthDay: string, time: string) => {
+  const { monthString, dayString } = getMonthDayString(monthDay);
+  const timeString = getTimeString(time);
+  const now = new Date();
+  let calculatedYear = now.getFullYear();
+  // if we're in december setting up a january scrim use correct year
+  if (monthString === "01" && now.getMonth() >= 1) {
+    calculatedYear++;
+  }
+  const dateStringNoOffset = `${calculatedYear}-${monthString}-${dayString}`;
+  const utcOffset = getUtcOffset(new Date(dateStringNoOffset));
+  const dateString = `${calculatedYear}-${monthString}-${dayString}T${timeString}${utcOffset}`;
+  return new Date(dateString);
+};
+
+const getMonthDayString = (monthDay: string) => {
+  const monthDaySplit = monthDay.split("/");
+  const month = Number(monthDaySplit[0]);
+  const day = Number(monthDaySplit[1]);
+  if (isNaN(month) || month <= 0 || month > 12) {
+    throw Error("Month not parseable");
+  } else if (isNaN(day) || day <= 0 || day > 31) {
+    throw Error("Day not parseable");
+  }
+  const monthString = String(month).padStart(2, "0");
+  const dayString = String(day).padStart(2, "0");
+  return { monthString, dayString };
+};
+
+// expected format hh:mm am
+const getTimeString = (time: string) => {
+  const timeArray = time.trim().split(" ");
+  const hourMinuteString = timeArray[0];
+  const ampmLabel = timeArray[1].toLowerCase();
+  const hourMinuteArray = hourMinuteString.split(":");
+  const hour = Number(hourMinuteArray[0]);
+  let minute = Number(hourMinuteArray[1]);
+  if (isNaN(hour) || hour <= 0 || hour > 12) {
+    throw Error("Hour not valid");
+  } else if (isNaN(minute)) {
+    minute = 0;
+  } else if (minute < 0 || minute > 59) {
+    throw Error("Minute not valid");
+  }
+
+  let hourString;
+  if (ampmLabel === "am") {
+    if (hour == 12) {
+      hourString = "00";
+    } else {
+      hourString = hour.toString().padStart(2, "0");
+    }
+    // check if 12, else keep same
+  } else if (ampmLabel === "pm") {
+    if (hour == 12) {
+      hourString = "12";
+    } else {
+      hourString = (hour + 12).toString().padStart(2, "0");
+    }
+  } else {
+    throw Error("am/pm label is invalid");
+  }
+  const minuteString = minute.toString().padStart(2, "0");
+  return `${hourString}:${minuteString}:00`;
+};
+
+// TODO once date-fns is merge in uncomment the conversion
+const getUtcOffset = (date: Date) => {
+  console.debug(date);
+  const offsetHours = 5; // getTimezoneOffset("America/New_York", date) / 60 / 60 / 1000;
+  return `-${String(Math.abs(offsetHours)).padStart(2, "0")}:00`;
+};

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -56,6 +56,10 @@ export abstract class Command extends SlashCommandBuilder {
     );
   }
 
+  formatDate(date: Date) {
+    return `<t:${Math.floor(date.valueOf() / 1000)}:f>`;
+  }
+
   async execute(interaction: ChatInputCommandInteraction): Promise<void> {
     if (this.isAdmin) {
       if (!isGuildMember(interaction.member)) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,5 @@
+import { Command } from "./command";
+import { AddPrioCommand } from "./admin/prio/add-prio";
+
+// TODO inject services to mock things even easier
+export const commands: Command[] = [new AddPrioCommand()];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,16 @@
 import { Command } from "./command";
 import { AddPrioCommand } from "./admin/prio/add-prio";
+import { ServerInfoCommand } from "./utility/server";
+import { PingCommand } from "./utility/ping";
+import { UserCommand } from "./utility/user";
 
 // TODO inject services to mock things even easier
-export const commands: Command[] = [new AddPrioCommand()];
+export const commands: Command[] = [
+  // test commands
+  new ServerInfoCommand(),
+  new PingCommand(),
+  new UserCommand(),
+
+  // custom commands
+  new AddPrioCommand(),
+];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -16,7 +16,6 @@ import { SignupCommand } from "./signup/sign-up";
 import { SubPlayerCommand } from "./signup/sub-player";
 import { prioService, rosterService, signupsService } from "../services";
 
-// TODO inject services to mock things even easier
 export const commands: Command[] = [
   // test commands
   new ServerInfoCommand(),

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,17 @@ import { AddPrioCommand } from "./admin/prio/add-prio";
 import { ServerInfoCommand } from "./utility/server";
 import { PingCommand } from "./utility/ping";
 import { UserCommand } from "./utility/user";
+import { ExpungePrioCommand } from "./admin/prio/expunge-prio";
+import { AddAdminRoleCommand } from "./admin/roles/add-admin-role";
+import { RemoveAdminRoleCommand } from "./admin/roles/remove-admin-role";
+import { CloseScrimCommand } from "./admin/scrim-crud/close-scrim";
+import { CreateScrimCommand } from "./admin/scrim-crud/create-scrim";
+import { GetSignupsCommand } from "./admin/scrim-crud/get-signups";
+import { ComputeScrimCommand } from "./admin/scrim-crud/compute-scrim";
+import { ChangeTeamNameCommand } from "./signup/change-team-name";
+import { DropoutCommand } from "./signup/droput-scrims";
+import { SignupCommand } from "./signup/sign-up";
+import { SubPlayerCommand } from "./signup/sub-player";
 
 // TODO inject services to mock things even easier
 export const commands: Command[] = [
@@ -13,4 +24,18 @@ export const commands: Command[] = [
 
   // custom commands
   new AddPrioCommand(),
+  new ExpungePrioCommand(),
+
+  new AddAdminRoleCommand(),
+  new RemoveAdminRoleCommand(),
+
+  new CreateScrimCommand(),
+  new GetSignupsCommand(),
+  new ComputeScrimCommand(),
+  new CloseScrimCommand(),
+
+  new ChangeTeamNameCommand(),
+  new DropoutCommand(),
+  new SignupCommand(),
+  new SubPlayerCommand(),
 ];

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,6 +14,7 @@ import { ChangeTeamNameCommand } from "./signup/change-team-name";
 import { DropoutCommand } from "./signup/droput-scrims";
 import { SignupCommand } from "./signup/sign-up";
 import { SubPlayerCommand } from "./signup/sub-player";
+import { prioService, rosterService, signupsService } from "../services";
 
 // TODO inject services to mock things even easier
 export const commands: Command[] = [
@@ -23,19 +24,19 @@ export const commands: Command[] = [
   new UserCommand(),
 
   // custom commands
-  new AddPrioCommand(),
+  new AddPrioCommand(prioService),
   new ExpungePrioCommand(),
 
   new AddAdminRoleCommand(),
   new RemoveAdminRoleCommand(),
 
-  new CreateScrimCommand(),
-  new GetSignupsCommand(),
-  new ComputeScrimCommand(),
-  new CloseScrimCommand(),
+  new CreateScrimCommand(signupsService),
+  new GetSignupsCommand(signupsService),
+  new ComputeScrimCommand(signupsService),
+  new CloseScrimCommand(signupsService),
 
   new ChangeTeamNameCommand(),
-  new DropoutCommand(),
-  new SignupCommand(),
+  new DropoutCommand(rosterService),
+  new SignupCommand(signupsService),
   new SubPlayerCommand(),
 ];

--- a/src/commands/interaction.ts
+++ b/src/commands/interaction.ts
@@ -1,0 +1,117 @@
+import {
+  CacheType,
+  ChatInputCommandInteraction,
+  CommandInteractionOptionResolver,
+} from "discord.js";
+import { getTimezoneOffset } from "date-fns-tz";
+
+type ExtendedCommandInteractionOptionResolver = Omit<
+  CommandInteractionOptionResolver<CacheType>,
+  "getMessage" | "getFocused"
+> & {
+  getDate(key: string, required?: boolean): Date | null;
+  // if date can't be parsed,
+  getDate(key: string, required: true): Date;
+};
+
+export const getCustomOptions = (
+  interaction: ChatInputCommandInteraction,
+): ExtendedCommandInteractionOptionResolver => {
+  return {
+    ...interaction.options,
+    getDate: (key: string, required?: boolean): Date => {
+      const dateString = interaction.options.getString(key);
+      try {
+        if (dateString) {
+          return parseDate(dateString, "12 am");
+        }
+      } catch (e) {
+        interaction.reply(
+          `Can't parse ${key}. Required: ${required ?? false}. ${e}`,
+        );
+        throw Error(
+          "Unable to parse a date argument that was " +
+            (required ? "required" : "supplied"),
+        );
+      }
+      // get around typescript expecting a date here, technically we are supplying the getDate(): Date | null function here
+      return null as unknown as Date;
+    },
+  };
+};
+
+export interface CustomInteraction extends ChatInputCommandInteraction {
+  options: ExtendedCommandInteractionOptionResolver;
+}
+
+const parseDate = (monthDay: string, time: string) => {
+  const { monthString, dayString } = getMonthDayString(monthDay);
+  const timeString = getTimeString(time);
+  const now = new Date();
+  let calculatedYear = now.getFullYear();
+  // if we're in december setting up a january scrim use correct year
+  if (monthString === "01" && now.getMonth() >= 1) {
+    calculatedYear++;
+  }
+  const dateStringNoOffset = `${calculatedYear}-${monthString}-${dayString}`;
+  const utcOffset = getUtcOffset(new Date(dateStringNoOffset));
+  const dateString = `${calculatedYear}-${monthString}-${dayString}T${timeString}${utcOffset}`;
+  return new Date(dateString);
+};
+
+const getMonthDayString = (monthDay: string) => {
+  const monthDaySplit = monthDay.split("/");
+  const month = Number(monthDaySplit[0]);
+  const day = Number(monthDaySplit[1]);
+  if (isNaN(month) || month <= 0 || month > 12) {
+    throw Error("Month not parseable");
+  } else if (isNaN(day) || day <= 0 || day > 31) {
+    throw Error("Day not parseable");
+  }
+  const monthString = String(month).padStart(2, "0");
+  const dayString = String(day).padStart(2, "0");
+  return { monthString, dayString };
+};
+
+// expected format hh:mm am
+const getTimeString = (time: string) => {
+  const timeArray = time.trim().split(" ");
+  const hourMinuteString = timeArray[0];
+  const ampmLabel = timeArray[1].toLowerCase();
+  const hourMinuteArray = hourMinuteString.split(":");
+  const hour = Number(hourMinuteArray[0]);
+  let minute = Number(hourMinuteArray[1]);
+  if (isNaN(hour) || hour <= 0 || hour > 12) {
+    throw Error("Hour not valid");
+  } else if (isNaN(minute)) {
+    minute = 0;
+  } else if (minute < 0 || minute > 59) {
+    throw Error("Minute not valid");
+  }
+
+  let hourString;
+  if (ampmLabel === "am") {
+    if (hour == 12) {
+      hourString = "00";
+    } else {
+      hourString = hour.toString().padStart(2, "0");
+    }
+    // check if 12, else keep same
+  } else if (ampmLabel === "pm") {
+    if (hour == 12) {
+      hourString = "12";
+    } else {
+      hourString = (hour + 12).toString().padStart(2, "0");
+    }
+  } else {
+    throw Error("am/pm label is invalid");
+  }
+  const minuteString = minute.toString().padStart(2, "0");
+  return `${hourString}:${minuteString}:00`;
+};
+
+const getUtcOffset = (date: Date) => {
+  const offsetHours =
+    getTimezoneOffset("America/New_York", date) / 60 / 60 / 1000;
+  return `-${String(Math.abs(offsetHours)).padStart(2, "0")}:00`;
+};

--- a/src/commands/interaction.ts
+++ b/src/commands/interaction.ts
@@ -3,7 +3,7 @@ import {
   ChatInputCommandInteraction,
   CommandInteractionOptionResolver,
 } from "discord.js";
-import { getTimezoneOffset } from "date-fns-tz";
+import { parseDate } from "../utility/time";
 
 type ExtendedCommandInteractionOptionResolver = Omit<
   CommandInteractionOptionResolver<CacheType>,
@@ -43,75 +43,3 @@ export const getCustomOptions = (
 export interface CustomInteraction extends ChatInputCommandInteraction {
   options: ExtendedCommandInteractionOptionResolver;
 }
-
-const parseDate = (monthDay: string, time: string) => {
-  const { monthString, dayString } = getMonthDayString(monthDay);
-  const timeString = getTimeString(time);
-  const now = new Date();
-  let calculatedYear = now.getFullYear();
-  // if we're in december setting up a january scrim use correct year
-  if (monthString === "01" && now.getMonth() >= 1) {
-    calculatedYear++;
-  }
-  const dateStringNoOffset = `${calculatedYear}-${monthString}-${dayString}`;
-  const utcOffset = getUtcOffset(new Date(dateStringNoOffset));
-  const dateString = `${calculatedYear}-${monthString}-${dayString}T${timeString}${utcOffset}`;
-  return new Date(dateString);
-};
-
-const getMonthDayString = (monthDay: string) => {
-  const monthDaySplit = monthDay.split("/");
-  const month = Number(monthDaySplit[0]);
-  const day = Number(monthDaySplit[1]);
-  if (isNaN(month) || month <= 0 || month > 12) {
-    throw Error("Month not parseable");
-  } else if (isNaN(day) || day <= 0 || day > 31) {
-    throw Error("Day not parseable");
-  }
-  const monthString = String(month).padStart(2, "0");
-  const dayString = String(day).padStart(2, "0");
-  return { monthString, dayString };
-};
-
-// expected format hh:mm am
-const getTimeString = (time: string) => {
-  const timeArray = time.trim().split(" ");
-  const hourMinuteString = timeArray[0];
-  const ampmLabel = timeArray[1].toLowerCase();
-  const hourMinuteArray = hourMinuteString.split(":");
-  const hour = Number(hourMinuteArray[0]);
-  let minute = Number(hourMinuteArray[1]);
-  if (isNaN(hour) || hour <= 0 || hour > 12) {
-    throw Error("Hour not valid");
-  } else if (isNaN(minute)) {
-    minute = 0;
-  } else if (minute < 0 || minute > 59) {
-    throw Error("Minute not valid");
-  }
-
-  let hourString;
-  if (ampmLabel === "am") {
-    if (hour == 12) {
-      hourString = "00";
-    } else {
-      hourString = hour.toString().padStart(2, "0");
-    }
-    // check if 12, else keep same
-  } else if (ampmLabel === "pm") {
-    if (hour == 12) {
-      hourString = "12";
-    } else {
-      hourString = (hour + 12).toString().padStart(2, "0");
-    }
-  } else {
-    throw Error("am/pm label is invalid");
-  }
-  const minuteString = minute.toString().padStart(2, "0");
-  return `${hourString}:${minuteString}:00`;
-};
-
-const getUtcOffset = (date: Date) => {
-  const offsetHours =
-    getTimezoneOffset("America/New_York", date) / 60 / 60 / 1000;
-  return `-${String(Math.abs(offsetHours)).padStart(2, "0")}:00`;
-};

--- a/src/commands/signup/change-team-name.ts
+++ b/src/commands/signup/change-team-name.ts
@@ -1,20 +1,15 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { CustomInteraction } from "../interaction";
+import { Command } from "../command";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("changeteamname")
-    .setDescription("Change the name of a team")
-    .addStringOption((option) =>
-      option
-        .setName("old-team-name")
-        .setDescription("Old name")
-        .setRequired(true),
-    )
-    .addStringOption((option) =>
-      option.setName("new-name").setDescription("New name").setRequired(true),
-    ),
+export class ChangeTeamNameCommand extends Command {
+  constructor() {
+    super("changeteamname", "Change the name of a team");
+    this.addStringInput("old-team-name", "Old name", true);
+    this.addStringInput("new-name", "New name", true);
+  }
 
-  async execute(interaction: ChatInputCommandInteraction) {
+  async run(interaction: CustomInteraction) {
     await interaction.reply("Fetched all input and working on your request!");
-  },
-};
+    // TODO implementation
+  }
+}

--- a/src/commands/signup/droput-scrims.ts
+++ b/src/commands/signup/droput-scrims.ts
@@ -1,21 +1,17 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { rosterService } from "../../services";
 import { isGuildMember } from "../../utility/utility";
+import { Command } from "../command";
+import { CustomInteraction } from "../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("dropout")
-    .setDescription("Drops a team from the signup list")
-    .addStringOption((option) =>
-      option
-        .setName("teamname")
-        .setDescription("Team name")
-        .setMinLength(1)
-        .setMaxLength(150)
-        .setRequired(true),
-    ),
+export class DropoutCommand extends Command {
+  constructor() {
+    super("dropout", "Drops a team from the signup list");
+    this.addStringInput("teamname", "Team name", true);
+    // .setMinLength(1)
+    // .setMaxLength(150)
+  }
 
-  async execute(interaction: ChatInputCommandInteraction) {
+  async run(interaction: CustomInteraction) {
     const channelId = interaction.channelId;
     const teamName = interaction.options.getString("teamname");
 
@@ -39,5 +35,5 @@ module.exports = {
       const error = e as Error;
       interaction.reply(`Did NOT remove team from scrim: ${error.message}`);
     }
-  },
-};
+  }
+}

--- a/src/commands/signup/droput-scrims.ts
+++ b/src/commands/signup/droput-scrims.ts
@@ -1,10 +1,10 @@
-import { rosterService } from "../../services";
 import { isGuildMember } from "../../utility/utility";
 import { Command } from "../command";
 import { CustomInteraction } from "../interaction";
+import { RosterService } from "../../services/rosters";
 
 export class DropoutCommand extends Command {
-  constructor() {
+  constructor(private rosterService: RosterService) {
     super("dropout", "Drops a team from the signup list");
     this.addStringInput("teamname", "Team name", true);
     // .setMinLength(1)
@@ -25,7 +25,7 @@ export class DropoutCommand extends Command {
     }
 
     try {
-      await rosterService.removeSignup(
+      await this.rosterService.removeSignup(
         interaction.member,
         channelId as string,
         teamName as string,

--- a/src/commands/signup/sign-up.ts
+++ b/src/commands/signup/sign-up.ts
@@ -1,29 +1,20 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 import { signupsService } from "../../services";
+import { Command } from "../command";
+import { CustomInteraction } from "../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("signup")
-    .setDescription("Creates a new scrim signup")
-    .addStringOption((option) =>
-      option
-        .setName("teamname")
-        .setDescription("Team name")
-        .setMinLength(1)
-        .setMaxLength(150)
-        .setRequired(true),
-    )
-    .addUserOption((option) =>
-      option.setName("player1").setDescription("@player1").setRequired(true),
-    )
-    .addUserOption((option) =>
-      option.setName("player2").setDescription("@player2").setRequired(true),
-    )
-    .addUserOption((option) =>
-      option.setName("player3").setDescription("@player3").setRequired(true),
-    ),
+export class SignupCommand extends Command {
+  constructor() {
+    super("signup", "Creates a new scrim signup");
+    this.addStringInput("teamname", "Team name", true);
+    //   .setMinLength(1)
+    // .setMaxLength(150)
 
-  async execute(interaction: ChatInputCommandInteraction) {
+    this.addUserInput("player1", "@player1", true);
+    this.addUserInput("player2", "@player2", true);
+    this.addUserInput("player3", "@player3", true);
+  }
+
+  async run(interaction: CustomInteraction) {
     const channelId = interaction.channelId;
     const teamName = interaction.options.getString("teamname");
     const signupPlayer = interaction.user;
@@ -62,5 +53,5 @@ module.exports = {
         "Associated scrim not found, team not created, this is probably a configuration error, contact admins",
       );
     }
-  },
-};
+  }
+}

--- a/src/commands/signup/sign-up.ts
+++ b/src/commands/signup/sign-up.ts
@@ -1,9 +1,9 @@
-import { signupsService } from "../../services";
 import { Command } from "../command";
 import { CustomInteraction } from "../interaction";
+import { ScrimSignups } from "../../services/signups";
 
 export class SignupCommand extends Command {
-  constructor() {
+  constructor(private signupService: ScrimSignups) {
     super("signup", "Creates a new scrim signup");
     this.addStringInput("teamname", "Team name", true);
     //   .setMinLength(1)
@@ -33,10 +33,10 @@ export class SignupCommand extends Command {
     }
 
     // TODO move getting scrimId into signups.addTeam method
-    const scrimId = signupsService.getScrimId(channelId as string);
+    const scrimId = this.signupService.getScrimId(channelId as string);
     if (scrimId) {
       try {
-        const signupId = await signupsService.addTeam(
+        const signupId = await this.signupService.addTeam(
           scrimId,
           teamName,
           signupPlayer,

--- a/src/commands/signup/sub-player.ts
+++ b/src/commands/signup/sub-player.ts
@@ -1,23 +1,15 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import { Command } from "../command";
+import { CustomInteraction } from "../interaction";
 
-module.exports = {
-  data: new SlashCommandBuilder()
-    .setName("subplayer")
-    .setDescription("Replace a player on a team")
-    .addUserOption((option) =>
-      option
-        .setName("remove-player")
-        .setDescription("Player to remove")
-        .setRequired(true),
-    )
-    .addUserOption((option) =>
-      option
-        .setName("add-player")
-        .setDescription("Player to add")
-        .setRequired(true),
-    ),
+export class SubPlayerCommand extends Command {
+  constructor() {
+    super("subplayer", "Replace a player on a team");
+    this.addUserInput("remove-player", "Player to remove", true);
+    this.addUserInput("add-player", "Player to add", true);
+  }
 
-  async execute(interaction: ChatInputCommandInteraction) {
+  async run(interaction: CustomInteraction) {
     await interaction.reply("Fetched all input and working on your request!");
-  },
-};
+    // TODO Implement
+  }
+}

--- a/src/commands/utility/ping.ts
+++ b/src/commands/utility/ping.ts
@@ -1,9 +1,12 @@
-import { SlashCommandBuilder, CommandInteraction } from "discord.js";
+import { CommandInteraction } from "discord.js";
+import { Command } from "../command";
 
-export const data = new SlashCommandBuilder()
-  .setName("ping")
-  .setDescription("Replies with Pong!");
+export class PingCommand extends Command {
+  constructor() {
+    super("ping", "Replies with Pong!");
+  }
 
-export async function execute(interaction: CommandInteraction): Promise<void> {
-  await interaction.reply("Pong!");
+  async run(interaction: CommandInteraction): Promise<void> {
+    await interaction.reply("Pong!");
+  }
 }

--- a/src/commands/utility/server.ts
+++ b/src/commands/utility/server.ts
@@ -1,19 +1,22 @@
-import { SlashCommandBuilder, CommandInteraction } from "discord.js";
+import { CommandInteraction } from "discord.js";
+import { Command } from "../command";
 
-export const data = new SlashCommandBuilder()
-  .setName("server")
-  .setDescription("Provides information about the server.");
+export class ServerInfoCommand extends Command {
+  constructor() {
+    super("server", "Provides information about the server.");
+  }
 
-export async function execute(interaction: CommandInteraction): Promise<void> {
-  const server = interaction.guild;
+  async run(interaction: CommandInteraction) {
+    const server = interaction.guild;
 
-  if (server) {
-    await interaction.reply(
-      `This server is ${server.name} and has ${server.memberCount} members.`,
-    );
-  } else {
-    await interaction.reply(
-      `I couldn't retrieve information about this server.`,
-    );
+    if (server) {
+      await interaction.reply(
+        `This server is ${server.name} and has ${server.memberCount} members.`,
+      );
+    } else {
+      await interaction.reply(
+        `I couldn't retrieve information about this server.`,
+      );
+    }
   }
 }

--- a/src/commands/utility/user.ts
+++ b/src/commands/utility/user.ts
@@ -1,30 +1,29 @@
-import {
-  SlashCommandBuilder,
-  CommandInteraction,
-  GuildMember,
-} from "discord.js";
+import { CommandInteraction, GuildMember } from "discord.js";
+import { Command } from "../command";
 
-export const data = new SlashCommandBuilder()
-  .setName("user")
-  .setDescription("Provides information about the user.");
+export class UserCommand extends Command {
+  constructor() {
+    super("user", "Provides information about the user.");
+  }
 
-export async function execute(interaction: CommandInteraction): Promise<void> {
-  const member = interaction.member;
+  async run(interaction: CommandInteraction): Promise<void> {
+    const member = interaction.member;
 
-  if (member instanceof GuildMember) {
-    const joinedAt = member.joinedAt;
-    if (joinedAt) {
-      await interaction.reply(
-        `This command was run by ${interaction.user.username}, who joined on ${joinedAt}.`,
-      );
+    if (member instanceof GuildMember) {
+      const joinedAt = member.joinedAt;
+      if (joinedAt) {
+        await interaction.reply(
+          `This command was run by ${interaction.user.username}, who joined on ${joinedAt}.`,
+        );
+      } else {
+        await interaction.reply(
+          `This command was run by ${interaction.user.username}, but I couldn't determine when they joined.`,
+        );
+      }
     } else {
       await interaction.reply(
         `This command was run by ${interaction.user.username}, but I couldn't determine when they joined.`,
       );
     }
-  } else {
-    await interaction.reply(
-      `This command was run by ${interaction.user.username}, but I couldn't determine when they joined.`,
-    );
   }
 }

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -1,7 +1,6 @@
 import { REST, Routes } from "discord.js";
 import fs from "node:fs";
 import path from "node:path";
-import { Command } from "./ExtendedClient"; // Adjust the import path as needed
 import type { RESTPostAPIChatInputApplicationCommandsJSONBody } from "../node_modules/@discordjs/builders/node_modules/discord-api-types/rest/v10/interactions.d.ts";
 interface Config {
   clientId: string;
@@ -10,6 +9,7 @@ interface Config {
 }
 
 import configJson from "../config.json";
+import { Command } from "./commands/command";
 const config: Config = configJson as Config;
 
 const commands: RESTPostAPIChatInputApplicationCommandsJSONBody[] = [];
@@ -35,8 +35,8 @@ for (const folder of commandFolders) {
     const command: Command = require(filePath) as Command;
 
     if ("data" in command && "execute" in command) {
-      commands.push(command.data.toJSON());
-      console.log(`Added command: ${command.data.name}`);
+      commands.push(command.toJSON());
+      console.log(`Added command: ${command.name}`);
     } else {
       console.log(
         `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`,

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -2,7 +2,7 @@ import { REST, Routes } from "discord.js";
 import fs from "node:fs";
 import path from "node:path";
 import { Command } from "./ExtendedClient"; // Adjust the import path as needed
-
+import type { RESTPostAPIChatInputApplicationCommandsJSONBody } from "../node_modules/@discordjs/builders/node_modules/discord-api-types/rest/v10/interactions.d.ts";
 interface Config {
   clientId: string;
   guildId: string;
@@ -12,7 +12,7 @@ interface Config {
 import configJson from "../config.json";
 const config: Config = configJson as Config;
 
-const commands: {}[] = [];
+const commands: RESTPostAPIChatInputApplicationCommandsJSONBody[] = [];
 // Grab all the command folders from the commands directory you created earlier
 const foldersPath = path.join(__dirname, "commands");
 const commandFolders = fs.readdirSync(foldersPath);

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,25 +1,8 @@
 import { Events } from "discord.js";
 
-// TODO can we delete this file?
 module.exports = {
   name: Events.InteractionCreate,
   async execute(interaction: any) {
-    if (interaction.customId === "scrimmodal") {
-      const teamName = interaction.fields.getTextInputValue("teamname");
-      const captain = interaction.fields.getTextInputValue("captain");
-      const player2 = interaction.fields.getTextInputValue("player2");
-      const player3 = interaction.fields.getTextInputValue("player3");
-
-      const captainId = await findUserIdByUsername(captain, interaction);
-      const player2Id = await findUserIdByUsername(player2, interaction);
-      const player3Id = await findUserIdByUsername(player3, interaction);
-
-      await interaction.reply(
-        `${teamName} <@${captainId}> <@${player2Id}> <@${player3Id}>`,
-      );
-      return;
-    }
-
     if (!interaction.isChatInputCommand()) return;
 
     const command = interaction.client.commands.get(interaction.commandName);
@@ -49,18 +32,3 @@ module.exports = {
     }
   },
 };
-
-async function findUserIdByUsername(username: string, interaction: any) {
-  try {
-    const guild = interaction.client.guilds.cache.first(); // Get the first guild the bot is in
-    if (!guild) return null;
-
-    const member = await guild.members.fetch({ query: username, limit: 1 });
-    if (member.size === 0) return null;
-
-    return member.first().user.id;
-  } catch (error) {
-    console.error("Error fetching user:", error);
-    return null;
-  }
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { GatewayIntentBits } from "discord.js";
 import config from "../config.json";
-import ExtendedClient, { Command } from "./ExtendedClient";
+import ExtendedClient from "./ExtendedClient";
+import { Command } from "./commands/command";
 
 const client = new ExtendedClient({ intents: [GatewayIntentBits.Guilds] });
 
@@ -20,7 +21,7 @@ for (const folder of commandFolders) {
     const command = require(filePath) as Command;
     // Set a new item in the Collection with the key as the command name and the value as the exported module
     if ("data" in command && "execute" in command) {
-      client.commands.set(command.data.name, command);
+      client.commands.set(command.name, command);
     } else {
       console.log(
         `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,14 @@
-import fs from "node:fs";
-import path from "node:path";
+import * as path from "node:path";
+import * as fs from "node:fs";
 import { GatewayIntentBits } from "discord.js";
 import config from "../config.json";
 import ExtendedClient from "./ExtendedClient";
-import { Command } from "./commands/command";
+import { commands } from "./commands";
 
 const client = new ExtendedClient({ intents: [GatewayIntentBits.Guilds] });
 
-const foldersPath = path.join(__dirname, "commands");
-const commandFolders = fs.readdirSync(foldersPath);
-
-// TODO I'm glad I found this duplicated code, we need to consolidate it
-for (const folder of commandFolders) {
-  const commandsPath = path.join(foldersPath, folder);
-  const commandFiles = fs
-    .readdirSync(commandsPath)
-    .filter((file) => file.endsWith(".ts") || file.endsWith(".js"));
-  for (const file of commandFiles) {
-    const filePath = path.join(commandsPath, file);
-    const command = require(filePath) as Command;
-    // Set a new item in the Collection with the key as the command name and the value as the exported module
-    if ("data" in command && "execute" in command) {
-      client.commands.set(command.name, command);
-    } else {
-      console.log(
-        `[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`,
-      );
-    }
-  }
+for (const command of commands) {
+  client.commands.set(command.name, command);
 }
 
 const eventsPath = path.join(__dirname, "events");

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ const client = new ExtendedClient({ intents: [GatewayIntentBits.Guilds] });
 const foldersPath = path.join(__dirname, "commands");
 const commandFolders = fs.readdirSync(foldersPath);
 
+// TODO I'm glad I found this duplicated code, we need to consolidate it
 for (const folder of commandFolders) {
   const commandsPath = path.join(foldersPath, folder);
   const commandFiles = fs

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -11,7 +11,7 @@ export const cache = new CacheService();
 export const overstatService = new OverstatService();
 
 export const authService = new AuthService(nhostDb, cache);
-export const prioService = new PrioService(nhostDb, cache, authService);
+export const prioService = new PrioService(nhostDb, cache);
 export const signupsService = new ScrimSignups(
   nhostDb,
   cache,

--- a/src/services/prio.ts
+++ b/src/services/prio.ts
@@ -1,6 +1,5 @@
 import { DB } from "../db/db";
-import { GuildMember, User } from "discord.js";
-import { AuthService } from "./auth";
+import { User } from "discord.js";
 import { CacheService } from "./cache";
 import { Scrim, ScrimSignup } from "../models/Scrims";
 import { ExpungedPlayerPrio, PlayerMap, PlayerPrio } from "../models/Prio";
@@ -9,35 +8,20 @@ export class PrioService {
   constructor(
     private db: DB,
     private cache: CacheService,
-    private authService: AuthService,
   ) {}
 
   async setPlayerPrio(
-    memberUsingCommand: GuildMember,
     prioUsers: User[],
     startDate: Date,
     endDate: Date,
     amount: number,
     reason: string,
   ) {
-    const isAuthorized =
-      await this.authService.memberIsAdmin(memberUsingCommand);
-    if (!isAuthorized) {
-      throw Error("User not authorized");
-    }
     const playerIds = await this.getPlayerIds(prioUsers);
     return await this.db.setPrio(playerIds, startDate, endDate, amount, reason);
   }
 
-  async expungePlayerPrio(
-    memberUsingCommand: GuildMember,
-    prioIds: string[],
-  ): Promise<ExpungedPlayerPrio[]> {
-    const isAuthorized =
-      await this.authService.memberIsAdmin(memberUsingCommand);
-    if (!isAuthorized) {
-      throw Error("User not authorized");
-    }
+  async expungePlayerPrio(prioIds: string[]): Promise<ExpungedPlayerPrio[]> {
     return await this.db.expungePrio(prioIds);
   }
 

--- a/src/utility/time.ts
+++ b/src/utility/time.ts
@@ -1,0 +1,93 @@
+import { formatInTimeZone, getTimezoneOffset } from "date-fns-tz";
+
+export const setEasternHours = (
+  date: Date,
+  hour: number,
+  min?: number,
+  sec?: number,
+  milli?: number,
+): Date => {
+  const hourFormat = String(hour).padStart(2, "0");
+  const dateString = formatInTimeZone(
+    date,
+    "America/New_York",
+    `yyyy-MM-dd ${hourFormat}:mm:ssxxxxx`,
+  ).replace(" ", "T");
+  const zonedDate = new Date(dateString);
+  zonedDate.setMinutes(min ?? date.getMinutes());
+  zonedDate.setSeconds(sec ?? date.getSeconds());
+  zonedDate.setMilliseconds(milli ?? date.getMilliseconds());
+  return zonedDate;
+};
+
+export const parseDate = (monthDay: string, time: string) => {
+  const { monthString, dayString } = getMonthDayString(monthDay);
+  const timeString = getTimeString(time);
+  const now = new Date();
+  let calculatedYear = now.getFullYear();
+  // if we're in december setting up a january scrim use correct year
+  if (monthString === "01" && now.getMonth() >= 1) {
+    calculatedYear++;
+  }
+  const dateStringNoOffset = `${calculatedYear}-${monthString}-${dayString}`;
+  const utcOffset = getUtcOffset(new Date(dateStringNoOffset));
+  const dateString = `${calculatedYear}-${monthString}-${dayString}T${timeString}${utcOffset}`;
+  return new Date(dateString);
+};
+
+const getMonthDayString = (monthDay: string) => {
+  const monthDaySplit = monthDay.split("/");
+  const month = Number(monthDaySplit[0]);
+  const day = Number(monthDaySplit[1]);
+  if (isNaN(month) || month <= 0 || month > 12) {
+    throw Error("Month not parseable");
+  } else if (isNaN(day) || day <= 0 || day > 31) {
+    throw Error("Day not parseable");
+  }
+  const monthString = String(month).padStart(2, "0");
+  const dayString = String(day).padStart(2, "0");
+  return { monthString, dayString };
+};
+
+// expected format hh:mm am
+const getTimeString = (time: string) => {
+  const timeArray = time.trim().split(" ");
+  const hourMinuteString = timeArray[0];
+  const ampmLabel = timeArray[1].toLowerCase();
+  const hourMinuteArray = hourMinuteString.split(":");
+  const hour = Number(hourMinuteArray[0]);
+  let minute = Number(hourMinuteArray[1]);
+  if (isNaN(hour) || hour <= 0 || hour > 12) {
+    throw Error("Hour not valid");
+  } else if (isNaN(minute)) {
+    minute = 0;
+  } else if (minute < 0 || minute > 59) {
+    throw Error("Minute not valid");
+  }
+
+  let hourString;
+  if (ampmLabel === "am") {
+    if (hour == 12) {
+      hourString = "00";
+    } else {
+      hourString = hour.toString().padStart(2, "0");
+    }
+    // check if 12, else keep same
+  } else if (ampmLabel === "pm") {
+    if (hour == 12) {
+      hourString = "12";
+    } else {
+      hourString = (hour + 12).toString().padStart(2, "0");
+    }
+  } else {
+    throw Error("am/pm label is invalid");
+  }
+  const minuteString = minute.toString().padStart(2, "0");
+  return `${hourString}:${minuteString}:00`;
+};
+
+const getUtcOffset = (date: Date) => {
+  const offsetHours =
+    getTimezoneOffset("America/New_York", date) / 60 / 60 / 1000;
+  return `-${String(Math.abs(offsetHours)).padStart(2, "0")}:00`;
+};

--- a/src/utility/utility.ts
+++ b/src/utility/utility.ts
@@ -1,31 +1,8 @@
 import { GuildMember } from "discord.js";
 import type { APIInteractionGuildMember } from "../../node_modules/discord-api-types/payloads/v10/_interactions/base.d.ts";
-import { toZonedTime } from "date-fns-tz";
 
 export function isGuildMember(
   value: GuildMember | APIInteractionGuildMember | null,
 ): value is GuildMember {
   return (value as GuildMember)?.roles !== undefined;
 }
-
-// same rules as date.setHours, if you send milli then all the previous arguments must be defined.
-export const setEasternHours = (
-  date: Date,
-  hour: number,
-  min?: number,
-  sec?: number,
-  milli?: number,
-): Date => {
-  const zonedDate = toZonedTime(date, "America/New_York");
-  // For some reason sending undefined is different than not sending anything, thanks JS
-  if (milli) {
-    zonedDate.setHours(hour, min, sec, milli);
-  } else if (sec) {
-    zonedDate.setHours(hour, min, sec);
-  } else if (min) {
-    zonedDate.setHours(hour, min);
-  } else {
-    zonedDate.setHours(hour);
-  }
-  return zonedDate;
-};

--- a/src/utility/utility.ts
+++ b/src/utility/utility.ts
@@ -1,8 +1,31 @@
 import { GuildMember } from "discord.js";
 import type { APIInteractionGuildMember } from "../../node_modules/discord-api-types/payloads/v10/_interactions/base.d.ts";
+import { toZonedTime } from "date-fns-tz";
 
 export function isGuildMember(
   value: GuildMember | APIInteractionGuildMember | null,
 ): value is GuildMember {
   return (value as GuildMember)?.roles !== undefined;
 }
+
+// same rules as date.setHours, if you send milli then all the previous arguments must be defined.
+export const setEasternHours = (
+  date: Date,
+  hour: number,
+  min?: number,
+  sec?: number,
+  milli?: number,
+): Date => {
+  const zonedDate = toZonedTime(date, "America/New_York");
+  // For some reason sending undefined is different than not sending anything, thanks JS
+  if (milli) {
+    zonedDate.setHours(hour, min, sec, milli);
+  } else if (sec) {
+    zonedDate.setHours(hour, min, sec);
+  } else if (min) {
+    zonedDate.setHours(hour, min);
+  } else {
+    zonedDate.setHours(hour);
+  }
+  return zonedDate;
+};

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -56,9 +56,9 @@ describe("Add prio", () => {
           }
         },
         getDate: (key: string) => {
-          if (key === "startDate") {
+          if (key === "startdate") {
             return new Date("1/12");
-          } else if (key === "endDate") {
+          } else if (key === "enddate") {
             return new Date("1/13");
           }
         },
@@ -85,9 +85,9 @@ describe("Add prio", () => {
           }
         },
         getDate: (key: string) => {
-          if (key === "startDate") {
+          if (key === "startdate") {
             return null;
-          } else if (key === "endDate") {
+          } else if (key === "enddate") {
             return new Date("1/13");
           }
         },

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -39,7 +39,7 @@ describe("Add prio", () => {
   let command: AddPrioCommand;
 
   beforeAll(() => {
-    command = new AddPrioCommand();
+    command = new AddPrioCommand(prioService);
 
     member = {
       roles: {},

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -1,5 +1,4 @@
 import {
-  ChatInputCommandInteraction,
   GuildMember,
   InteractionReplyOptions,
   InteractionResponse,
@@ -7,17 +6,16 @@ import {
   Snowflake,
   User,
 } from "discord.js";
-import { authService, prioService } from "../../../../src/services";
+import { prioService } from "../../../../src/services";
 import SpyInstance = jest.SpyInstance;
 import { AddPrioCommand } from "../../../../src/commands/admin/prio/add-prio";
+import { CustomInteraction } from "../../../../src/commands/interaction";
 
 describe("Add prio", () => {
   // this is supposed to be a Snowflake but I don't want to mock it strings work just fine
   const channelId = "some id" as unknown as Snowflake;
-  let basicInteraction: ChatInputCommandInteraction;
-  let singleUserInteraction: ChatInputCommandInteraction;
-  let incorrectStartDateInteraction: ChatInputCommandInteraction;
-  let incorrectEndDateInteraction: ChatInputCommandInteraction;
+  let basicInteraction: CustomInteraction;
+  let singleUserInteraction: CustomInteraction;
 
   let setPlayerPrioSpy: SpyInstance<
     Promise<string[]>,
@@ -32,10 +30,6 @@ describe("Add prio", () => {
   >;
   let member: GuildMember;
   const supreme: User = { displayName: "Supreme", id: "1" } as unknown as User;
-  const theHeuman: User = {
-    displayName: "TheHeuman",
-    id: "2",
-  } as unknown as User;
   let replySpy: SpyInstance<
     Promise<InteractionResponse<boolean>>,
     [reply: string | InteractionReplyOptions | MessagePayload],
@@ -59,10 +53,13 @@ describe("Add prio", () => {
         getString: (key: string) => {
           if (key === "reason") {
             return "Prio reason";
-          } else if (key === "startDate") {
-            return "1/12";
+          }
+        },
+        getDate: (key: string) => {
+          if (key === "startDate") {
+            return new Date("1/12");
           } else if (key === "endDate") {
-            return "1/13";
+            return new Date("1/13");
           }
         },
         getNumber: () => -400,
@@ -72,7 +69,7 @@ describe("Add prio", () => {
       },
       channelId,
       member,
-    } as unknown as ChatInputCommandInteraction;
+    } as unknown as CustomInteraction;
 
     singleUserInteraction = {
       options: {
@@ -85,10 +82,13 @@ describe("Add prio", () => {
         getString: (key: string) => {
           if (key === "reason") {
             return "Prio reason";
-          } else if (key === "startDate") {
-            return "1/12";
+          }
+        },
+        getDate: (key: string) => {
+          if (key === "startDate") {
+            return null;
           } else if (key === "endDate") {
-            return "1/13";
+            return new Date("1/13");
           }
         },
         getNumber: () => -400,
@@ -98,52 +98,19 @@ describe("Add prio", () => {
       },
       channelId,
       member,
-    } as unknown as ChatInputCommandInteraction;
+    } as unknown as CustomInteraction;
 
-    incorrectStartDateInteraction = {
-      options: {
-        getUser: () => theHeuman,
-        getString: (key: string) => {
-          if (key === "reason") {
-            return "Prio reason";
-          } else if (key === "startDate") {
-            return "lol";
-          } else if (key === "endDate") {
-            return "no";
-          }
-        },
-        getNumber: () => -400,
-      },
-      reply: (message: string) => {
-        console.log("Replying to command with:", message);
-      },
-      channelId,
-    } as unknown as ChatInputCommandInteraction;
-    incorrectEndDateInteraction = {
-      options: {
-        getUser: () => theHeuman,
-        getString: (key: string) => {
-          if (key === "reason") {
-            return "Prio reason";
-          } else if (key === "startDate") {
-            return "1/12";
-          } else if (key === "endDate") {
-            return "11/no";
-          }
-        },
-        getNumber: () => -400,
-      },
-      reply: (message: string) => {
-        console.log("Replying to command with:", message);
-      },
-      channelId,
-    } as unknown as ChatInputCommandInteraction;
     setPlayerPrioSpy = jest.spyOn(prioService, "setPlayerPrio");
     setPlayerPrioSpy.mockClear();
     setPlayerPrioSpy.mockReturnValue(Promise.resolve([]));
   });
 
   it("Should add prio to 1 user", async () => {
+    const fakeDate = new Date("2024-12-14T22:30:00-05:00");
+    console.log("System time", fakeDate);
+    jest.useFakeTimers();
+    jest.setSystemTime(fakeDate);
+
     setPlayerPrioSpy.mockImplementation(
       (
         prioUsers: User[],
@@ -162,10 +129,11 @@ describe("Add prio", () => {
     replySpy = jest.spyOn(singleUserInteraction, "reply");
     await command.run(singleUserInteraction);
     expect(replySpy).toHaveBeenCalledWith(
-      "Added -400 prio to 1 player from 1/12 to 1/13 because Prio reason. Supreme prio id: db id",
+      "Added -400 prio to 1 player from 12/14 10:30 PM to 1/13 11:59 PM because Prio reason. Supreme prio id: db id",
     );
-    // if this is failing, and you haven't changed the amount of assertions take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
+    // if this is failing, and you haven't changed the amount of assertions take, a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
     expect.assertions(4);
+    jest.setSystemTime(jest.getRealSystemTime());
   });
 
   it("Should add prio to multiple users", async () => {
@@ -187,37 +155,21 @@ describe("Add prio", () => {
     replySpy = jest.spyOn(basicInteraction, "reply");
     await command.run(basicInteraction);
     expect(replySpy).toHaveBeenCalledWith(
-      "Added -400 prio to 3 players from 1/12 to 1/13 because Prio reason. Supreme prio id: db id; Supreme prio id: db id 2; Supreme prio id: db id 3",
+      "Added -400 prio to 3 players from 1/12 12:00 AM to 1/13 11:59 PM because Prio reason. Supreme prio id: db id; Supreme prio id: db id 2; Supreme prio id: db id 3",
     );
-    // if this is failing, and you haven't changed the amount of assertions take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
+    // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
     expect.assertions(4);
   });
 
-  describe("errors", () => {
-    beforeEach(() => {
-      setPlayerPrioSpy.mockImplementation(() => {
-        return Promise.resolve([]);
-      });
+  it("Should reply with an error if setPrio fails", async () => {
+    setPlayerPrioSpy.mockImplementation(() => {
+      return Promise.reject("The database fell asleep");
     });
 
-    it("should not add prio because the start date is incorrectly formatted", async () => {
-      setPlayerPrioSpy.mockClear();
-      replySpy = jest.spyOn(incorrectStartDateInteraction, "reply");
-      await command.run(incorrectStartDateInteraction);
-      expect(replySpy).toHaveBeenCalledWith(
-        "Can't parse start date Error: Month not parseable",
-      );
-      expect(setPlayerPrioSpy).not.toHaveBeenCalled();
-    });
-
-    it("should not add prio because the end date is incorrectly formatted", async () => {
-      setPlayerPrioSpy.mockClear();
-      replySpy = jest.spyOn(incorrectEndDateInteraction, "reply");
-      await command.run(incorrectEndDateInteraction);
-      expect(replySpy).toHaveBeenCalledWith(
-        "Can't parse end date Error: Day not parseable",
-      );
-      expect(setPlayerPrioSpy).not.toHaveBeenCalled();
-    });
+    replySpy = jest.spyOn(basicInteraction, "reply");
+    await command.run(basicInteraction);
+    expect(replySpy).toHaveBeenCalledWith(
+      "Error while executing set prio: The database fell asleep",
+    );
   });
 });

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -7,21 +7,21 @@ import {
   Snowflake,
   User,
 } from "discord.js";
-import { prioService } from "../../../../src/services";
+import { authService, prioService } from "../../../../src/services";
 import SpyInstance = jest.SpyInstance;
-
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const addPrioCommand = require("../../../../src/commands/admin/prio/add-prio");
+import { AddPrioCommand } from "../../../../src/commands/admin/prio/add-prio";
 
 describe("Add prio", () => {
   // this is supposed to be a Snowflake but I don't want to mock it strings work just fine
   const channelId = "some id" as unknown as Snowflake;
   let basicInteraction: ChatInputCommandInteraction;
-  let noMemberInteraction: ChatInputCommandInteraction;
+  let singleUserInteraction: ChatInputCommandInteraction;
+  let incorrectStartDateInteraction: ChatInputCommandInteraction;
+  let incorrectEndDateInteraction: ChatInputCommandInteraction;
+
   let setPlayerPrioSpy: SpyInstance<
     Promise<string[]>,
     [
-      memberUsingCommand: GuildMember,
       prioUsers: User[],
       startDate: Date,
       endDate: Date,
@@ -42,13 +42,30 @@ describe("Add prio", () => {
     string
   >;
 
+  let command: AddPrioCommand;
+
   beforeAll(() => {
+    command = new AddPrioCommand();
+
     member = {
       roles: {},
     } as GuildMember;
+
+    let singleUserInteractionGetUserCount = 0;
+
     basicInteraction = {
       options: {
         getUser: () => supreme,
+        getString: (key: string) => {
+          if (key === "reason") {
+            return "Prio reason";
+          } else if (key === "startDate") {
+            return "1/12";
+          } else if (key === "endDate") {
+            return "1/13";
+          }
+        },
+        getNumber: () => -400,
       },
       reply: (message: string) => {
         console.log("Replying to command with:", message);
@@ -56,16 +73,65 @@ describe("Add prio", () => {
       channelId,
       member,
     } as unknown as ChatInputCommandInteraction;
-    noMemberInteraction = {
+
+    singleUserInteraction = {
+      options: {
+        getUser: () => {
+          if (singleUserInteractionGetUserCount === 0) {
+            singleUserInteractionGetUserCount++;
+            return supreme;
+          }
+        },
+        getString: (key: string) => {
+          if (key === "reason") {
+            return "Prio reason";
+          } else if (key === "startDate") {
+            return "1/12";
+          } else if (key === "endDate") {
+            return "1/13";
+          }
+        },
+        getNumber: () => -400,
+      },
+      reply: (message: string) => {
+        console.log("Replying to command with:", message);
+      },
+      channelId,
+      member,
+    } as unknown as ChatInputCommandInteraction;
+
+    incorrectStartDateInteraction = {
       options: {
         getUser: () => theHeuman,
         getString: (key: string) => {
           if (key === "reason") {
             return "Prio reason";
-          } else if (key === "amount") {
-            return "-400";
+          } else if (key === "startDate") {
+            return "lol";
+          } else if (key === "endDate") {
+            return "no";
           }
         },
+        getNumber: () => -400,
+      },
+      reply: (message: string) => {
+        console.log("Replying to command with:", message);
+      },
+      channelId,
+    } as unknown as ChatInputCommandInteraction;
+    incorrectEndDateInteraction = {
+      options: {
+        getUser: () => theHeuman,
+        getString: (key: string) => {
+          if (key === "reason") {
+            return "Prio reason";
+          } else if (key === "startDate") {
+            return "1/12";
+          } else if (key === "endDate") {
+            return "11/no";
+          }
+        },
+        getNumber: () => -400,
       },
       reply: (message: string) => {
         console.log("Replying to command with:", message);
@@ -77,17 +143,40 @@ describe("Add prio", () => {
     setPlayerPrioSpy.mockReturnValue(Promise.resolve([]));
   });
 
-  it("Should add prio", async () => {
+  it("Should add prio to 1 user", async () => {
     setPlayerPrioSpy.mockImplementation(
       (
-        memberUsingCommand: GuildMember,
         prioUsers: User[],
         _: Date,
         __: Date,
         amount: number,
         reason: string,
       ) => {
-        expect(memberUsingCommand).toEqual(member);
+        expect(prioUsers).toEqual([supreme]);
+        expect(amount).toEqual(-400);
+        expect(reason).toEqual("Prio reason");
+        return Promise.resolve(["db id"]);
+      },
+    );
+
+    replySpy = jest.spyOn(singleUserInteraction, "reply");
+    await command.run(singleUserInteraction);
+    expect(replySpy).toHaveBeenCalledWith(
+      "Added -400 prio to 1 player from 1/12 to 1/13 because Prio reason. Supreme prio id: db id",
+    );
+    // if this is failing, and you haven't changed the amount of assertions take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
+    expect.assertions(4);
+  });
+
+  it("Should add prio to multiple users", async () => {
+    setPlayerPrioSpy.mockImplementation(
+      (
+        prioUsers: User[],
+        _: Date,
+        __: Date,
+        amount: number,
+        reason: string,
+      ) => {
         expect(prioUsers).toEqual([supreme, supreme, supreme]);
         expect(amount).toEqual(-400);
         expect(reason).toEqual("Prio reason");
@@ -96,21 +185,37 @@ describe("Add prio", () => {
     );
 
     replySpy = jest.spyOn(basicInteraction, "reply");
-    await addPrioCommand.execute(basicInteraction);
+    await command.run(basicInteraction);
     expect(replySpy).toHaveBeenCalledWith(
-      "Added -400 prio to 3 players from 1/12/25 to 1/13/25 because Prio reason. Supreme added prio with id: db id; Supreme added prio with id: db id 2; Supreme added prio with id: db id 3",
+      "Added -400 prio to 3 players from 1/12 to 1/13 because Prio reason. Supreme prio id: db id; Supreme prio id: db id 2; Supreme prio id: db id 3",
     );
     // if this is failing, and you haven't changed the amount of assertions take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
-    expect.assertions(5);
+    expect.assertions(4);
   });
 
   describe("errors", () => {
-    it("should not add prio because there is no member", async () => {
+    beforeEach(() => {
+      setPlayerPrioSpy.mockImplementation(() => {
+        return Promise.resolve([]);
+      });
+    });
+
+    it("should not add prio because the start date is incorrectly formatted", async () => {
       setPlayerPrioSpy.mockClear();
-      replySpy = jest.spyOn(noMemberInteraction, "reply");
-      await addPrioCommand.execute(noMemberInteraction);
+      replySpy = jest.spyOn(incorrectStartDateInteraction, "reply");
+      await command.run(incorrectStartDateInteraction);
       expect(replySpy).toHaveBeenCalledWith(
-        "Can't find the member issuing the command or this is an api command, no command executed",
+        "Can't parse start date Error: Month not parseable",
+      );
+      expect(setPlayerPrioSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not add prio because the end date is incorrectly formatted", async () => {
+      setPlayerPrioSpy.mockClear();
+      replySpy = jest.spyOn(incorrectEndDateInteraction, "reply");
+      await command.run(incorrectEndDateInteraction);
+      expect(replySpy).toHaveBeenCalledWith(
+        "Can't parse end date Error: Day not parseable",
       );
       expect(setPlayerPrioSpy).not.toHaveBeenCalled();
     });

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -57,9 +57,9 @@ describe("Add prio", () => {
         },
         getDate: (key: string) => {
           if (key === "startdate") {
-            return new Date("1/12");
+            return new Date("2025-01-12T00:00:00-05:00");
           } else if (key === "enddate") {
-            return new Date("1/13");
+            return new Date("2025-01-13T00:00:00-05:00");
           }
         },
         getNumber: () => -400,
@@ -88,7 +88,7 @@ describe("Add prio", () => {
           if (key === "startdate") {
             return null;
           } else if (key === "enddate") {
-            return new Date("1/13");
+            return new Date("2025-01-13T00:00:00-05:00");
           }
         },
         getNumber: () => -400,
@@ -129,9 +129,9 @@ describe("Add prio", () => {
     replySpy = jest.spyOn(singleUserInteraction, "reply");
     await command.run(singleUserInteraction);
     expect(replySpy).toHaveBeenCalledWith(
-      "Added -400 prio to 1 player from 12/14 10:30 PM to 1/13 11:59 PM because Prio reason. Supreme prio id: db id",
+      `Added -400 prio to 1 player from <t:${Math.floor(fakeDate.valueOf() / 1000)}:f> to <t:${Math.floor(new Date("2025-01-13T23:59:59-05:00").valueOf() / 1000)}:f> because Prio reason. Supreme prio id: db id`,
     );
-    // if this is failing, and you haven't changed the amount of assertions take, a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
+    // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
     expect.assertions(4);
     jest.setSystemTime(jest.getRealSystemTime());
   });
@@ -155,7 +155,7 @@ describe("Add prio", () => {
     replySpy = jest.spyOn(basicInteraction, "reply");
     await command.run(basicInteraction);
     expect(replySpy).toHaveBeenCalledWith(
-      "Added -400 prio to 3 players from 1/12 12:00 AM to 1/13 11:59 PM because Prio reason. Supreme prio id: db id; Supreme prio id: db id 2; Supreme prio id: db id 3",
+      `Added -400 prio to 3 players from ${command.formatDate(new Date("2025-01-12T00:00:00-05:00"))} to ${command.formatDate(new Date("2025-01-13T23:59:59-05:00"))} because Prio reason. Supreme prio id: db id; Supreme prio id: db id 2; Supreme prio id: db id 3`,
     );
     // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
     expect.assertions(4);

--- a/test/commands/command.test.ts
+++ b/test/commands/command.test.ts
@@ -10,10 +10,11 @@ import { authService } from "../../src/services";
 import SpyInstance = jest.SpyInstance;
 import { MockCommand } from "../mocks/command.mock";
 
-describe("Add prio", () => {
+describe("abstract command", () => {
   let basicInteraction: ChatInputCommandInteraction;
   let noMemberInteraction: ChatInputCommandInteraction;
   let unAuthorizedMemberInteraction: ChatInputCommandInteraction;
+
   let runSpy: SpyInstance<
     Promise<void>,
     [interaction: ChatInputCommandInteraction],

--- a/test/commands/command.test.ts
+++ b/test/commands/command.test.ts
@@ -1,0 +1,124 @@
+import {
+  ChatInputCommandInteraction,
+  GuildMember,
+  InteractionReplyOptions,
+  InteractionResponse,
+  MessagePayload,
+  User,
+} from "discord.js";
+import { authService } from "../../src/services";
+import SpyInstance = jest.SpyInstance;
+import { MockCommand } from "../mocks/command.mock";
+
+describe("Add prio", () => {
+  let basicInteraction: ChatInputCommandInteraction;
+  let noMemberInteraction: ChatInputCommandInteraction;
+  let unAuthorizedMemberInteraction: ChatInputCommandInteraction;
+  let runSpy: SpyInstance<
+    Promise<void>,
+    [interaction: ChatInputCommandInteraction],
+    string
+  >;
+  let member: GuildMember;
+  const theHeuman: User = {
+    displayName: "TheHeuman",
+    id: "2",
+  } as unknown as User;
+  let replySpy: SpyInstance<
+    Promise<InteractionResponse<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
+    string
+  >;
+
+  let command: MockCommand;
+
+  beforeAll(() => {
+    command = new MockCommand(true);
+
+    member = {
+      id: "authorized",
+      roles: {},
+    } as GuildMember;
+
+    basicInteraction = {
+      reply: (message: string) => {
+        console.log("Basic replying to command with:", message);
+      },
+      member,
+    } as unknown as ChatInputCommandInteraction;
+    noMemberInteraction = {
+      options: {
+        getUser: () => theHeuman,
+        getString: (key: string) => {
+          if (key === "reason") {
+            return "Prio reason";
+          } else if (key === "amount") {
+            return "-400";
+          }
+        },
+      },
+      reply: (message: string) => {
+        console.log("NoMember replying to command with:", message);
+      },
+    } as unknown as ChatInputCommandInteraction;
+    unAuthorizedMemberInteraction = {
+      reply: (message: string) => {
+        console.log("Unauthorized replying to command with:", message);
+      },
+      member: {
+        id: "unauthorized",
+        roles: {},
+      } as GuildMember,
+    } as unknown as ChatInputCommandInteraction;
+  });
+
+  beforeEach(() => {
+    runSpy = jest.spyOn(command, "run");
+
+    jest
+      .spyOn(authService, "memberIsAdmin")
+      .mockImplementation((member) =>
+        Promise.resolve(member.id === "authorized"),
+      );
+  });
+
+  it("Should call child class run command because member is authorized", async () => {
+    runSpy.mockClear();
+    replySpy = jest.spyOn(basicInteraction, "reply");
+    await command.execute(basicInteraction);
+    expect(runSpy).toHaveBeenCalledWith(basicInteraction);
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("Should call child class run command because member does not need to be authorized", async () => {
+    command.isAdmin = false;
+    runSpy.mockClear();
+    replySpy = jest.spyOn(noMemberInteraction, "reply");
+    await command.execute(noMemberInteraction);
+    expect(runSpy).toHaveBeenCalledWith(noMemberInteraction);
+    expect(replySpy).not.toHaveBeenCalled();
+    command.isAdmin = true;
+  });
+
+  describe("errors", () => {
+    it("should not call run command because there is no member", async () => {
+      runSpy.mockClear();
+      replySpy = jest.spyOn(noMemberInteraction, "reply");
+      await command.execute(noMemberInteraction);
+      expect(replySpy).toHaveBeenCalledWith(
+        "Can't find the member issuing the command or this is an api command, no command executed",
+      );
+      expect(runSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not call run command because member is not authorized", async () => {
+      runSpy.mockClear();
+      replySpy = jest.spyOn(unAuthorizedMemberInteraction, "reply");
+      await command.execute(unAuthorizedMemberInteraction);
+      expect(replySpy).toHaveBeenCalledWith(
+        "User calling command is not authorized",
+      );
+      expect(runSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/commands/interaction.test.ts
+++ b/test/commands/interaction.test.ts
@@ -1,0 +1,115 @@
+import {
+  ChatInputCommandInteraction,
+  GuildMember,
+  InteractionReplyOptions,
+  InteractionResponse,
+  MessagePayload,
+  User,
+} from "discord.js";
+import { authService } from "../../src/services";
+import SpyInstance = jest.SpyInstance;
+import { MockCommand } from "../mocks/command.mock";
+import { getCustomOptions } from "../../src/commands/interaction";
+
+describe("Custom interaction", () => {
+  let correctDateInteraction: ChatInputCommandInteraction;
+  let malformedMonthInteraction: ChatInputCommandInteraction;
+  let malformedDayInteraction: ChatInputCommandInteraction;
+  let missingStringInteraction: ChatInputCommandInteraction;
+
+  let replySpy: SpyInstance<
+    Promise<InteractionResponse<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
+    string
+  >;
+
+  beforeAll(() => {
+    correctDateInteraction = {
+      options: {
+        getString: () => "11/12",
+      },
+      reply: (message: string) => {
+        console.log("Basic replying to command with:", message);
+      },
+    } as unknown as ChatInputCommandInteraction;
+
+    malformedDayInteraction = {
+      options: {
+        getString: () => "11/no",
+      },
+      reply: (message: string) => {
+        console.log("Replying to command with:", message);
+      },
+    } as unknown as ChatInputCommandInteraction;
+
+    malformedMonthInteraction = {
+      options: {
+        getString: () => "lol/12",
+      },
+      reply: (message: string) => {
+        console.log("Replying to command with:", message);
+      },
+    } as unknown as ChatInputCommandInteraction;
+
+    missingStringInteraction = {
+      options: {
+        getString: () => null,
+      },
+      reply: (message: string) => {
+        console.log("Replying to command with:", message);
+      },
+    } as unknown as ChatInputCommandInteraction;
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2024-11-14"));
+  });
+
+  afterEach(() => {
+    jest.setSystemTime(jest.getRealSystemTime());
+    jest.useRealTimers();
+  });
+
+  it("Should return a correct date", async () => {
+    const customOptions = getCustomOptions(correctDateInteraction);
+    const date = customOptions.getDate("date");
+    expect(date).toEqual(new Date("2024-11-12T00:00:00-05:00"));
+  });
+
+  it("should return null when date is not required and string does not exist", async () => {
+    const customOptions = getCustomOptions(missingStringInteraction);
+    const date = customOptions.getDate("date");
+    expect(date).toEqual(null);
+  });
+
+  describe("errors", () => {
+    it("should throw error when date is not required and string exists", async () => {
+      replySpy = jest.spyOn(malformedMonthInteraction, "reply");
+      const customOptions = getCustomOptions(malformedMonthInteraction);
+      const expectErrors = () => {
+        customOptions.getDate("date");
+      };
+      expect(expectErrors).toThrow(
+        "Unable to parse a date argument that was supplied",
+      );
+      expect(replySpy).toHaveBeenCalledWith(
+        "Can't parse date. Required: false. Error: Month not parseable",
+      );
+    });
+
+    it("should throw error when date is required", async () => {
+      replySpy = jest.spyOn(malformedDayInteraction, "reply");
+      const customOptions = getCustomOptions(malformedDayInteraction);
+      const expectErrors = () => {
+        customOptions.getDate("date", true);
+      };
+      expect(expectErrors).toThrow(
+        "Unable to parse a date argument that was required",
+      );
+      expect(replySpy).toHaveBeenCalledWith(
+        "Can't parse date. Required: true. Error: Day not parseable",
+      );
+    });
+  });
+});

--- a/test/mocks/command.mock.ts
+++ b/test/mocks/command.mock.ts
@@ -1,0 +1,13 @@
+import { Command } from "../../src/commands/command";
+import { ChatInputCommandInteraction } from "discord.js";
+
+export class MockCommand extends Command {
+  constructor(isAdmin: boolean) {
+    super("mockcommand", "fake command to test abstract class", isAdmin);
+  }
+
+  run(interaction: ChatInputCommandInteraction) {
+    console.log("Mock command run called", interaction.member);
+    return Promise.resolve();
+  }
+}

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -12,7 +12,6 @@ import { ScrimSignup } from "../../src/models/Scrims";
 import { OverstatTournamentResponse } from "../../src/models/overstatModels";
 import { mockOverstatResponse } from "../mocks/overstat-response.mock";
 import { PrioService } from "../../src/services/prio";
-import { AuthService } from "../../src/services/auth";
 import { ScrimSignupsWithPlayers } from "../../src/db/table.interfaces";
 
 describe("Signups", () => {
@@ -26,11 +25,7 @@ describe("Signups", () => {
     dbMock = new DbMock();
     cache = new CacheService();
     overstatService = new OverstatService();
-    prioService = new PrioService(
-      dbMock,
-      cache,
-      new AuthService(dbMock, cache),
-    );
+    prioService = new PrioService(dbMock, cache);
     signups = new ScrimSignups(dbMock, cache, overstatService, prioService);
   });
 


### PR DESCRIPTION
* create abstract command class that simplifies some regular functionality
  * all commands now extend this class
  * check for admin correctly
  * add getDate() argument that all commands can use without parsing individually
  * add date-fns and date-fns-tz for date parsing
* remove admin checking in prio service since its done at command level now 
* refactor deploy-commands and main entry file to stop importing commands incorrectly
* implement add prio as full finished example
* inject services into commands (potential here for mocking while testing things)
* add readme for how to add a command
