### PR TITLE
Bugfix/smoke-test

### DIFF
--- a/src/commands/README.md
+++ b/src/commands/README.md
@@ -19,7 +19,8 @@
   * add all the inputs necessary for your command by using the applicable parent methods or by adding new parent methods where necessary
     * required inputs must be added first
 * in your run method you must reply within 3 seconds so discord doesn't trash your interaction
-  * if you're doing async work you should reply with a generic message saying "working on your request" or something of the like
+  * The admin command already replies for you since it has to do some db checks, so admin commands will just use editReply
+  * for member commands if you're doing async work you should reply with a generic message saying "working on your request" or something of the like
 
 admin command example: 
 ```
@@ -49,7 +50,7 @@ export class NameOfYourCommand extends AdminCommand {
     const numberInput: number | null = interaction.options.getNumber(this.inputNames.number);
     const stringInput: string = interaction.options.getString(this.inputNames.string
     
-    interaction.reply("Got your command, working on it!"
+    interaction.editReply("Got your command, working on it!"
     await this.service.someMethod()
     interaction.editReply("useful information about the work that was executed")
   }

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -51,6 +51,11 @@ export class AddPrioCommand extends AdminCommand {
       this.inputNames.endDate,
       true,
     );
+
+    await interaction.reply({
+      content: "Fetched all input and working on your request!",
+    });
+
     // end date is inclusive
     endDate = setEasternHours(endDate, 23, 59, 59);
 
@@ -65,14 +70,14 @@ export class AddPrioCommand extends AdminCommand {
         reason,
       );
     } catch (e) {
-      await interaction.reply("Error while executing set prio: " + e);
+      await interaction.editReply("Error while executing set prio: " + e);
       return;
     }
 
     const prioIdString = dbIds
       .map((dbId, index) => `${users[index]?.displayName} prio id: ${dbId}`)
       .join("\n");
-    await interaction.reply(
+    await interaction.editReply(
       `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${this.formatDate(startDate)} to ${this.formatDate(endDate)}\nReason: ${reason}.\nID's:\n${prioIdString}`,
     );
   }

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -19,7 +19,7 @@ export class AddPrioCommand extends AdminCommand {
     authService: AuthService,
     private prioService: PrioService,
   ) {
-    super(authService, "addprio", "Adds a prio entry for up to three players");
+    super(authService, "add-prio", "Adds a prio entry for up to three players");
 
     this.addUserInput(this.inputNames.user1, "First user", true);
     this.addDateInput(this.inputNames.endDate, "End date", true);
@@ -75,7 +75,7 @@ export class AddPrioCommand extends AdminCommand {
     }
 
     const prioIdString = dbIds
-      .map((dbId, index) => `${users[index]?.displayName} prio id: ${dbId}`)
+      .map((dbId, index) => `<@${users[index]?.id}> prio id: ${dbId}`)
       .join("\n");
     await interaction.editReply(
       `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${this.formatDate(startDate)} to ${this.formatDate(endDate)}\nReason: ${reason}.\nID's:\n${prioIdString}`,

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -52,7 +52,7 @@ export class AddPrioCommand extends AdminCommand {
       true,
     );
 
-    await interaction.reply({
+    await interaction.editReply({
       content: "Fetched all input and working on your request!",
     });
 

--- a/src/commands/admin/roles/add-admin-role.ts
+++ b/src/commands/admin/roles/add-admin-role.ts
@@ -16,7 +16,7 @@ export class AddAdminRoleCommand extends AdminCommand {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
-    await interaction.reply({
+    await interaction.editReply({
       content: "Fetched all input and working on your request!",
     });
     // TODO implement

--- a/src/commands/admin/roles/remove-admin-role.ts
+++ b/src/commands/admin/roles/remove-admin-role.ts
@@ -16,7 +16,7 @@ export class RemoveAdminRoleCommand extends AdminCommand {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
-    await interaction.reply({
+    await interaction.editReply({
       content: "Fetched all input and working on your request!",
     });
     // TODO implement

--- a/src/commands/admin/scrim-crud/close-scrim.ts
+++ b/src/commands/admin/scrim-crud/close-scrim.ts
@@ -24,7 +24,7 @@ export class CloseScrimCommand extends AdminCommand {
       );
       return;
     }
-    await interaction.reply({
+    await interaction.editReply({
       content: "Fetched all input and working on your request!",
     });
 

--- a/src/commands/admin/scrim-crud/compute-scrim.ts
+++ b/src/commands/admin/scrim-crud/compute-scrim.ts
@@ -25,7 +25,7 @@ export class ComputeScrimCommand extends AdminCommand {
   }
 
   async run(interaction: CustomInteraction) {
-    await interaction.reply({
+    await interaction.editReply({
       content: "Fetched all input and working on your request!",
     });
     const channelId = interaction.channelId;

--- a/src/commands/admin/scrim-crud/create-scrim.ts
+++ b/src/commands/admin/scrim-crud/create-scrim.ts
@@ -60,7 +60,7 @@ export class CreateScrimCommand extends AdminCommand {
       return;
     }
 
-    await interaction.reply({
+    await interaction.editReply({
       content: "Fetched all input and working on your request!",
     });
 

--- a/src/commands/admin/scrim-crud/get-signups.ts
+++ b/src/commands/admin/scrim-crud/get-signups.ts
@@ -35,15 +35,41 @@ export class GetSignupsCommand extends AdminCommand {
     const { mainList, waitList } = channelSignups;
 
     const mainListString = `Main list.\n${this.formatTeams(mainList)}`;
-    const waitListString =
-      waitList.length > 0
-        ? `\n\n\nWait list.\n${this.formatTeams(waitList)}`
-        : "";
-    const message = mainListString + waitListString;
-    await interaction.editReply(message);
+
+    await this.replyWithString(interaction, mainListString);
+
+    if (waitList.length > 0) {
+      const waitListString = `Wait list.\n${this.formatTeams(waitList)}`;
+      await this.replyWithString(interaction, waitListString);
+    }
   }
 
-  formatTeams(teams: ScrimSignup[]) {
-    return teams.map((team) => this.formatTeam(team)).join("\n");
+  // Break long strings into chunks for discord
+  async replyWithString(interaction: CustomInteraction, replyString: string) {
+    let stringToReplyWith = replyString;
+    while (stringToReplyWith.length > 0) {
+      // discords max reply length is 2000
+      let cutoffIndex =
+        stringToReplyWith.length > 2000 ? 2000 : stringToReplyWith.length;
+      let charAtIndex = stringToReplyWith.charAt(cutoffIndex - 1);
+      while (charAtIndex !== "\n") {
+        cutoffIndex--;
+        charAtIndex = stringToReplyWith.charAt(cutoffIndex - 1);
+      }
+      const message = stringToReplyWith.substring(0, cutoffIndex);
+      try {
+        await interaction.followUp({ content: message, ephemeral: true });
+      } catch (e) {
+        await interaction.followUp({
+          content: "error sending part of response " + e,
+          ephemeral: true,
+        });
+      }
+      stringToReplyWith = stringToReplyWith.substring(cutoffIndex);
+    }
+  }
+
+  formatTeams(teams: ScrimSignup[]): string {
+    return teams.map((team) => this.formatTeam(team)).join("\n") + "\n";
   }
 }

--- a/src/commands/admin/scrim-crud/get-signups.ts
+++ b/src/commands/admin/scrim-crud/get-signups.ts
@@ -20,7 +20,7 @@ export class GetSignupsCommand extends AdminCommand {
     // Before executing any other code, we need to acknowledge the interaction.
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
-    await interaction.invisibleReply("Fetching teams, command in progress");
+    await interaction.editReply("Fetching teams, command in progress");
 
     const channelId = interaction.channelId;
 

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -139,6 +139,7 @@ export abstract class AdminCommand extends Command {
   }
 
   async childExecute(interaction: CustomInteraction) {
+    await interaction.invisibleReply("Checking if user is authorized");
     if (!isGuildMember(interaction.member)) {
       await interaction.reply(
         "Can't find the member issuing the command or this is an api command, no command executed",

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -346,7 +346,15 @@ export abstract class DB {
         "player_three_id",
         "scrim_id",
       ],
-    ) as Promise<JSONValue>;
+    ) as Promise<
+      {
+        team_name: string;
+        player_one_id: string;
+        player_two_id: string;
+        player_three_id: string;
+        scrim_id: string;
+      }[]
+    >;
   }
 
   async setPrio(

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -1,6 +1,12 @@
 import { PlayerInsert, PlayerStatInsert } from "../models/Player";
 import { ScrimSignupsWithPlayers } from "./table.interfaces";
-import { DbTable, DbValue, JSONValue, LogicalExpression } from "./types";
+import {
+  Comparator,
+  DbTable,
+  DbValue,
+  JSONValue,
+  LogicalExpression,
+} from "./types";
 import { DiscordRole } from "../models/Role";
 import { ExpungedPlayerPrio } from "../models/Prio";
 
@@ -10,12 +16,12 @@ export abstract class DB {
     logicalExpression: LogicalExpression | undefined,
     fieldsToReturn: K[],
   ): Promise<Array<Record<K, DbValue>>>;
-  abstract update(
+  abstract update<K extends string>(
     tableName: DbTable,
     logicalExpression: LogicalExpression,
     fieldsToUpdate: Record<string, DbValue>,
-    fieldsToReturn: string[],
-  ): Promise<JSONValue>;
+    fieldsToReturn: K[],
+  ): Promise<Array<Record<K, DbValue>>>;
   // returns id of new object as a string
   abstract post(
     tableName: DbTable,
@@ -73,18 +79,17 @@ export abstract class DB {
     skill: number,
     playerStats: PlayerStatInsert[],
   ): Promise<string[]> {
-    const updatedScrimInfo: { id: string } = (await this.update(
+    const updatedScrimInfo: { id: DbValue }[] = await this.update(
       DbTable.scrims,
       {
         fieldName: "id",
         comparator: "eq",
         value: scrimId,
       },
-
       { skill, overstat_link: overstatLink },
       ["id"],
-    )) as { id: string };
-    if (!updatedScrimInfo?.id) {
+    );
+    if (!updatedScrimInfo[0].id) {
       throw Error(
         "Could not set skill level or overstat link on scrim, no updates made",
       );
@@ -95,27 +100,24 @@ export abstract class DB {
     );
   }
 
-  async closeScrim(scrimId: string): Promise<string[]> {
-    const updatedScrimInfo: { id: string } = (await this.update(
+  async closeScrim(discordChannelID: string): Promise<string[]> {
+    const equateExpression = {
+      fieldName: "discord_channel",
+      comparator: "eq" as Comparator,
+      value: discordChannelID,
+    };
+    const updatedScrimInfo: { id: DbValue }[] = await this.update(
       DbTable.scrims,
-      {
-        fieldName: "id",
-        comparator: "eq",
-        value: scrimId,
-      },
+      equateExpression,
       { active: false },
       ["id"],
-    )) as { id: string };
-    if (!updatedScrimInfo?.id) {
-      throw Error("Could not set scrim to inactive, no updates made");
+    );
+    if (!updatedScrimInfo[0].id) {
+      throw Error("Could not set scrim(s) to inactive, no updates made");
     }
     const deletedEntries = await this.delete(
       DbTable.scrimSignups,
-      {
-        fieldName: "scrim_id",
-        comparator: "eq",
-        value: updatedScrimInfo.id,
-      },
+      equateExpression,
       ["id"],
     );
     return deletedEntries.map((entry) => entry.id as string);
@@ -344,7 +346,7 @@ export abstract class DB {
         "player_three_id",
         "scrim_id",
       ],
-    );
+    ) as Promise<JSONValue>;
   }
 
   async setPrio(

--- a/src/db/nhost.db.ts
+++ b/src/db/nhost.db.ts
@@ -171,12 +171,12 @@ class NhostDb extends DB {
     return returnedData[deleteName].returning;
   }
 
-  async update(
+  async update<K extends string>(
     tableName: string,
     fieldsToSearch: LogicalExpression,
     fieldsToUpdate: Record<string, DbValue>,
-    fieldsToReturn: string[],
-  ): Promise<JSONValue> {
+    fieldsToReturn: K[],
+  ): Promise<Array<Record<K, DbValue>>> {
     const updateName = "update_" + tableName;
     const searchString = this.generateWhereClause(fieldsToSearch);
     const fieldsToUpdateArray = Object.keys(fieldsToUpdate).map(
@@ -199,9 +199,11 @@ class NhostDb extends DB {
     if (!result.data || result.error) {
       throw Error("Graph ql error: " + result.error);
     }
-    const returnedData: Record<string, { returning: { id: string }[] }> =
-      result.data as Record<string, { returning: { id: string }[] }>;
-    return returnedData[updateName].returning[0];
+    const returnedData = result.data as Record<
+      string,
+      { returning: Array<Record<K, DbValue>> }
+    >;
+    return returnedData[updateName].returning;
   }
 
   async changeTeamName(

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -136,7 +136,7 @@ describe("Add prio", () => {
     editReplySpy = jest.spyOn(singleUserInteraction, "editReply");
     await command.run(singleUserInteraction);
     expect(editReplySpy).toHaveBeenCalledWith(
-      `Added -400 prio to 1 player from <t:${Math.floor(fakeDate.valueOf() / 1000)}:f> to <t:${Math.floor(new Date("2025-01-13T23:59:59-05:00").valueOf() / 1000)}:f>\nReason: Prio reason.\nID's:\nSupreme prio id: db id`,
+      `Added -400 prio to 1 player from <t:${Math.floor(fakeDate.valueOf() / 1000)}:f> to <t:${Math.floor(new Date("2025-01-13T23:59:59-05:00").valueOf() / 1000)}:f>\nReason: Prio reason.\nID's:\n<@1> prio id: db id`,
     );
     // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
     expect.assertions(4);
@@ -162,7 +162,7 @@ describe("Add prio", () => {
     editReplySpy = jest.spyOn(basicInteraction, "editReply");
     await command.run(basicInteraction);
     expect(editReplySpy).toHaveBeenCalledWith(
-      `Added -400 prio to 3 players from ${command.formatDate(new Date("2025-01-12T00:00:00-05:00"))} to ${command.formatDate(new Date("2025-01-13T23:59:59-05:00"))}\nReason: Prio reason.\nID's:\nSupreme prio id: db id\nSupreme prio id: db id 2\nSupreme prio id: db id 3`,
+      `Added -400 prio to 3 players from ${command.formatDate(new Date("2025-01-12T00:00:00-05:00"))} to ${command.formatDate(new Date("2025-01-13T23:59:59-05:00"))}\nReason: Prio reason.\nID's:\n<@1> prio id: db id\n<@1> prio id: db id 2\n<@1> prio id: db id 3`,
     );
     // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
     expect.assertions(4);

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -1,7 +1,9 @@
 import {
   GuildMember,
+  InteractionEditReplyOptions,
   InteractionReplyOptions,
   InteractionResponse,
+  Message,
   MessagePayload,
   Snowflake,
   User,
@@ -33,9 +35,9 @@ describe("Add prio", () => {
   >;
   let member: GuildMember;
   const supreme: User = { displayName: "Supreme", id: "1" } as unknown as User;
-  let replySpy: SpyInstance<
-    Promise<InteractionResponse<boolean>>,
-    [reply: string | InteractionReplyOptions | MessagePayload],
+  let editReplySpy: SpyInstance<
+    Promise<Message<boolean>>,
+    [reply: string | InteractionEditReplyOptions | MessagePayload],
     string
   >;
 
@@ -73,6 +75,7 @@ describe("Add prio", () => {
         getNumber: () => -400,
       },
       reply: jest.fn(),
+      editReply: jest.fn(),
       channelId,
       member,
     } as unknown as CustomInteraction;
@@ -100,6 +103,7 @@ describe("Add prio", () => {
         getNumber: () => -400,
       },
       reply: jest.fn(),
+      editReply: jest.fn(),
       channelId,
       member,
     } as unknown as CustomInteraction;
@@ -129,9 +133,9 @@ describe("Add prio", () => {
       },
     );
 
-    replySpy = jest.spyOn(singleUserInteraction, "reply");
+    editReplySpy = jest.spyOn(singleUserInteraction, "editReply");
     await command.run(singleUserInteraction);
-    expect(replySpy).toHaveBeenCalledWith(
+    expect(editReplySpy).toHaveBeenCalledWith(
       `Added -400 prio to 1 player from <t:${Math.floor(fakeDate.valueOf() / 1000)}:f> to <t:${Math.floor(new Date("2025-01-13T23:59:59-05:00").valueOf() / 1000)}:f>\nReason: Prio reason.\nID's:\nSupreme prio id: db id`,
     );
     // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
@@ -155,9 +159,9 @@ describe("Add prio", () => {
       },
     );
 
-    replySpy = jest.spyOn(basicInteraction, "reply");
+    editReplySpy = jest.spyOn(basicInteraction, "editReply");
     await command.run(basicInteraction);
-    expect(replySpy).toHaveBeenCalledWith(
+    expect(editReplySpy).toHaveBeenCalledWith(
       `Added -400 prio to 3 players from ${command.formatDate(new Date("2025-01-12T00:00:00-05:00"))} to ${command.formatDate(new Date("2025-01-13T23:59:59-05:00"))}\nReason: Prio reason.\nID's:\nSupreme prio id: db id\nSupreme prio id: db id 2\nSupreme prio id: db id 3`,
     );
     // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
@@ -169,9 +173,9 @@ describe("Add prio", () => {
       return Promise.reject("The database fell asleep");
     });
 
-    replySpy = jest.spyOn(basicInteraction, "reply");
+    editReplySpy = jest.spyOn(basicInteraction, "editReply");
     await command.run(basicInteraction);
-    expect(replySpy).toHaveBeenCalledWith(
+    expect(editReplySpy).toHaveBeenCalledWith(
       "Error while executing set prio: The database fell asleep",
     );
   });

--- a/test/commands/command.test.ts
+++ b/test/commands/command.test.ts
@@ -88,7 +88,6 @@ describe("abstract command", () => {
     replySpy = jest.spyOn(basicInteraction, "reply");
     await adminCommand.execute(basicInteraction);
     expect(runSpy).toHaveBeenCalledWith(basicInteraction);
-    expect(replySpy).not.toHaveBeenCalled();
   });
 
   it("Should call child class run command because member does not need to be authorized", async () => {

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -393,13 +393,15 @@ describe("DB connection", () => {
           "scrim_id",
         ],
       );
-      expect(newData).toEqual({
-        team_name: "Dude Cube",
-        player_one_id: "f272a11e-5b30-4aea-b596-af2464de59ba",
-        player_two_id: "c450684a-d423-4e52-b6ea-0778bf021910",
-        player_three_id: "7605b2bf-1875-4415-a04b-75fe47768565",
-        scrim_id: "ebb385a2-ba18-43b7-b0a3-44f2ff5589b9",
-      });
+      expect(newData).toEqual([
+        {
+          team_name: "Dude Cube",
+          player_one_id: "f272a11e-5b30-4aea-b596-af2464de59ba",
+          player_two_id: "c450684a-d423-4e52-b6ea-0778bf021910",
+          player_three_id: "7605b2bf-1875-4415-a04b-75fe47768565",
+          scrim_id: "ebb385a2-ba18-43b7-b0a3-44f2ff5589b9",
+        },
+      ]);
       expect.assertions(2);
     });
   });
@@ -844,7 +846,7 @@ describe("DB connection", () => {
   describe("close and compute scrim", () => {
     const expectedDeleteQuery = `
       mutation {
-        delete_scrim_signups(where: { scrim_id: { _eq: "ebb385a2-ba18-43b7-b0a3-44f2ff5589b9" } }) {
+        delete_scrim_signups(where: { discord_channel: { _eq: "discord_channel_id" } }) {
           returning {
             id
           }
@@ -883,7 +885,7 @@ describe("DB connection", () => {
         let expected = `
         mutation {
          update_scrims(
-           where: { id: { _eq: "ebb385a2-ba18-43b7-b0a3-44f2ff5589b9" } },
+           where: { discord_channel: { _eq: "discord_channel_id" } },
           _set:
           {
             active: false
@@ -901,7 +903,10 @@ describe("DB connection", () => {
             update_scrims: {
               returning: [
                 {
-                  id: "ebb385a2-ba18-43b7-b0a3-44f2ff5589b9",
+                  id: "7d3bc090-f9aa-4d74-a686-7ab198ab2dfe",
+                },
+                {
+                  id: "9766e780-3c13-4298-8eed-a3cf9a206db4",
                 },
               ],
             },
@@ -929,9 +934,7 @@ describe("DB connection", () => {
         );
         return Promise.resolve(returnData);
       };
-      const returnedData = await nhostDb.closeScrim(
-        "ebb385a2-ba18-43b7-b0a3-44f2ff5589b9",
-      );
+      const returnedData = await nhostDb.closeScrim("discord_channel_id");
       expect(returnedData).toEqual([
         "7d3bc090-f9aa-4d74-a686-7ab198ab2dfe",
         "9766e780-3c13-4298-8eed-a3cf9a206db4",

--- a/test/mocks/db.mock.ts
+++ b/test/mocks/db.mock.ts
@@ -106,13 +106,13 @@ export class DbMock extends DB {
     return Promise.resolve({});
   }
 
-  update(
+  update<K extends string>(
     tableName: string,
     fieldsToEquate: LogicalExpression,
     fieldsToUpdate: Record<string, DbValue>,
-    fieldsToReturn: string[],
-  ): Promise<JSONValue> {
-    return Promise.resolve({});
+    fieldsToReturn: K[],
+  ): Promise<Array<Record<K, DbValue>>> {
+    return Promise.resolve([]);
   }
 
   changeTeamName(


### PR DESCRIPTION
* get-signups command now complies with discords 2k character limit by splitting the message up in to pieces
* Reply immediately to all admin commands before auth service check
* add prio command now ats users so they get a notification
* DB.closeScrim now closes all scrims from the specified channel
* DB.update method now uses generics to return a list of records changed with the requested properties
  * changeTeamNameNoAuth now returns correctly typed promise