### PR TITLE
feature/visible-reply

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Get the signups for a scrim, only sends the list to the user calling the command
 Can only be used in a signup post created by the bot
 
 #### /compute-scrim
-Computes stats for the scrim, any overstat accounts linked to discord accounts will have stats generated for them weighted to the lobby strength if sent.
+Computes stats for the scrim, any overstat accounts linked to discord accounts will have stats generated for them weighted to the lobby strength.
 
 This command can be used multiple times in the same signup post if there are multiple lobbies
 
@@ -78,9 +78,7 @@ This command can be used multiple times in the same signup post if there are mul
 Can only be used in a signup post created by the bot
 
 
-Fill out the required fields: full overstat link (not shortened)
-
-Optionally add skill to it so it can be weighted properly
+Fill out the required fields: full overstat link (not shortened), skill (see below table for skill for each type of lobby)
 
 Skill map
 ```

--- a/src/commands/admin/prio/add-prio.ts
+++ b/src/commands/admin/prio/add-prio.ts
@@ -77,7 +77,8 @@ export class AddPrioCommand extends AdminCommand {
     const prioIdString = dbIds
       .map((dbId, index) => `<@${users[index]?.id}> prio id: ${dbId}`)
       .join("\n");
-    await interaction.editReply(
+    await interaction.deleteReply();
+    await interaction.followUp(
       `Added ${amount} prio to ${users.length} player${users.length === 1 ? "" : "s"} from ${this.formatDate(startDate)} to ${this.formatDate(endDate)}\nReason: ${reason}.\nID's:\n${prioIdString}`,
     );
   }

--- a/src/commands/admin/roles/add-admin-role.ts
+++ b/src/commands/admin/roles/add-admin-role.ts
@@ -23,7 +23,8 @@ export class AddAdminRoleCommand extends AdminCommand {
       await this.authService.addAdminRoles([
         { discordRoleId: role.id, roleName: role.name },
       ]);
-      await interaction.editReply(`Scrim bot admin role <@&${role.id}> added`);
+      await interaction.deleteReply();
+      await interaction.followUp(`Scrim bot admin role <@&${role.id}> added`);
     } catch (e) {
       await interaction.editReply("Error while adding admin role. " + e);
     }

--- a/src/commands/admin/roles/remove-admin-role.ts
+++ b/src/commands/admin/roles/remove-admin-role.ts
@@ -21,9 +21,8 @@ export class RemoveAdminRoleCommand extends AdminCommand {
 
     try {
       await this.authService.removeAdminRoles([role.id]);
-      await interaction.editReply(
-        `Scrim bot admin role <@&${role.id}> removed`,
-      );
+      await interaction.deleteReply();
+      await interaction.followUp(`Scrim bot admin role <@&${role.id}> removed`);
     } catch (e) {
       await interaction.editReply("Error while removing admin role. " + e);
     }

--- a/src/commands/admin/scrim-crud/close-scrim.ts
+++ b/src/commands/admin/scrim-crud/close-scrim.ts
@@ -31,18 +31,20 @@ export class CloseScrimCommand extends AdminCommand {
     try {
       await this.signupService.closeScrim(channel.id);
     } catch (error) {
-      interaction.editReply("Scrim not closed. " + error);
+      await interaction.editReply("Scrim not closed. " + error);
       return;
     }
 
-    interaction.editReply("Scrim closed. Deleting this channel in 5 seconds");
+    await interaction.editReply(
+      "Scrim closed. Deleting this channel in 5 seconds",
+    );
     setTimeout(async () => {
       try {
         await channel.delete(
           "Scrim closed by " + interaction.member?.user.username,
         );
       } catch (error) {
-        interaction.editReply(
+        await interaction.editReply(
           "Scrim closed but channel could not be deleted. " + error,
         );
         return;

--- a/src/commands/admin/scrim-crud/compute-scrim.ts
+++ b/src/commands/admin/scrim-crud/compute-scrim.ts
@@ -21,25 +21,25 @@ export class ComputeScrimCommand extends AdminCommand {
         minLength: 30,
       },
     );
-    this.addNumberInput("skill", "Skill level of the lobby");
+    this.addNumberInput("skill", "Skill level of the lobby", true);
   }
 
   async run(interaction: CustomInteraction) {
-    await interaction.editReply({
-      content: "Fetched all input and working on your request!",
-    });
     const channelId = interaction.channelId;
     const overstatLink = interaction.options.getString("overstat-link", true);
     const skill = interaction.options.getNumber("skill", true);
+    await interaction.editReply({
+      content: "Fetched all input and working on your request!",
+    });
 
     try {
       await this.signupService.computeScrim(channelId, overstatLink, skill);
+      await interaction.deleteReply();
+      await interaction.followUp(
+        "Scrim lobby successfully computed, you can now compute another lobby or close the scrim",
+      );
     } catch (error) {
       await interaction.editReply(`Scrim not computed. ${error}`);
     }
-
-    await interaction.editReply(
-      "Scrim lobby successfully computed, you can now compute another lobby or close the scrim",
-    );
   }
 }

--- a/src/commands/admin/scrim-crud/create-scrim.ts
+++ b/src/commands/admin/scrim-crud/create-scrim.ts
@@ -54,7 +54,7 @@ export class CreateScrimCommand extends AdminCommand {
 
     // just to triple check
     if (!isForumChannel(channel)) {
-      await interaction.reply(
+      await interaction.editReply(
         "Scrim post could not be created. Channel provided is not a forum channel",
       );
       return;
@@ -92,7 +92,8 @@ export class CreateScrimCommand extends AdminCommand {
       return;
     }
 
-    await interaction.editReply(
+    await interaction.deleteReply();
+    await interaction.followUp(
       `Scrim created. Channel: <#${createdThread.id}>`,
     );
   }

--- a/src/db/nhost.db.ts
+++ b/src/db/nhost.db.ts
@@ -162,7 +162,6 @@ class NhostDb extends DB {
       error: GraphQLError[] | ErrorPayload | null;
     } = await this.nhostClient.graphql.request(query);
     if (!result.data || result.error) {
-      console.log(result.data, result.error);
       throw Error("Graph ql error: " + result.error);
     }
     const returnedData = result.data as Record<

--- a/src/db/nhost.db.ts
+++ b/src/db/nhost.db.ts
@@ -162,6 +162,7 @@ class NhostDb extends DB {
       error: GraphQLError[] | ErrorPayload | null;
     } = await this.nhostClient.graphql.request(query);
     if (!result.data || result.error) {
+      console.log(result.data, result.error);
       throw Error("Graph ql error: " + result.error);
     }
     const returnedData = result.data as Record<

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -93,7 +93,7 @@ export class ScrimSignups {
     if (!scrimId) {
       throw Error("No scrim found for that channel");
     }
-    await this.db.closeScrim(scrimId);
+    await this.db.closeScrim(discordChannelID);
     this.cache.removeScrimChannel(discordChannelID);
   }
 

--- a/test/commands/admin/prio/add-prio.test.ts
+++ b/test/commands/admin/prio/add-prio.test.ts
@@ -40,6 +40,11 @@ describe("Add prio", () => {
     [reply: string | InteractionEditReplyOptions | MessagePayload],
     string
   >;
+  let followUpSpy: SpyInstance<
+    Promise<Message<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
+    string
+  >;
 
   const mockPrioService = new PrioServiceMock();
 
@@ -74,8 +79,9 @@ describe("Add prio", () => {
         },
         getNumber: () => -400,
       },
-      reply: jest.fn(),
       editReply: jest.fn(),
+      followUp: jest.fn(),
+      deleteReply: jest.fn(),
       channelId,
       member,
     } as unknown as CustomInteraction;
@@ -102,11 +108,17 @@ describe("Add prio", () => {
         },
         getNumber: () => -400,
       },
-      reply: jest.fn(),
       editReply: jest.fn(),
+      followUp: jest.fn(),
+      deleteReply: jest.fn(),
       channelId,
       member,
     } as unknown as CustomInteraction;
+
+    editReplySpy = jest.spyOn(basicInteraction, "editReply");
+    editReplySpy.mockClear();
+    followUpSpy = jest.spyOn(basicInteraction, "followUp");
+    followUpSpy.mockClear();
 
     setPlayerPrioSpy = jest.spyOn(mockPrioService, "setPlayerPrio");
     setPlayerPrioSpy.mockClear();
@@ -133,9 +145,9 @@ describe("Add prio", () => {
       },
     );
 
-    editReplySpy = jest.spyOn(singleUserInteraction, "editReply");
+    followUpSpy = jest.spyOn(singleUserInteraction, "followUp");
     await command.run(singleUserInteraction);
-    expect(editReplySpy).toHaveBeenCalledWith(
+    expect(followUpSpy).toHaveBeenCalledWith(
       `Added -400 prio to 1 player from <t:${Math.floor(fakeDate.valueOf() / 1000)}:f> to <t:${Math.floor(new Date("2025-01-13T23:59:59-05:00").valueOf() / 1000)}:f>\nReason: Prio reason.\nID's:\n<@1> prio id: db id`,
     );
     // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values
@@ -159,9 +171,9 @@ describe("Add prio", () => {
       },
     );
 
-    editReplySpy = jest.spyOn(basicInteraction, "editReply");
+    followUpSpy = jest.spyOn(basicInteraction, "followUp");
     await command.run(basicInteraction);
-    expect(editReplySpy).toHaveBeenCalledWith(
+    expect(followUpSpy).toHaveBeenCalledWith(
       `Added -400 prio to 3 players from ${command.formatDate(new Date("2025-01-12T00:00:00-05:00"))} to ${command.formatDate(new Date("2025-01-13T23:59:59-05:00"))}\nReason: Prio reason.\nID's:\n<@1> prio id: db id\n<@1> prio id: db id 2\n<@1> prio id: db id 3`,
     );
     // if this is failing, and you haven't changed the amount of assertions, take a look a little higher in the log to see if the setPlayerPrioSpy was called with differing values

--- a/test/commands/admin/roles/add-admin-role.test.ts
+++ b/test/commands/admin/roles/add-admin-role.test.ts
@@ -1,5 +1,6 @@
 import {
   InteractionEditReplyOptions,
+  InteractionReplyOptions,
   Message,
   MessagePayload,
 } from "discord.js";
@@ -23,6 +24,11 @@ describe("Add admin role", () => {
     [reply: string | InteractionEditReplyOptions | MessagePayload],
     string
   >;
+  let followUpSpy: SpyInstance<
+    Promise<Message<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
+    string
+  >;
 
   const mockAuthService = new AuthMock();
 
@@ -39,10 +45,14 @@ describe("Add admin role", () => {
         }),
       },
       editReply: jest.fn(),
+      followUp: jest.fn(),
+      deleteReply: jest.fn(),
     } as unknown as CustomInteraction;
 
     editReplySpy = jest.spyOn(basicInteraction, "editReply");
     editReplySpy.mockClear();
+    followUpSpy = jest.spyOn(basicInteraction, "followUp");
+    followUpSpy.mockClear();
     addAdminRoleSpy = jest.spyOn(mockAuthService, "addAdminRoles");
     addAdminRoleSpy.mockClear();
   });
@@ -53,7 +63,7 @@ describe("Add admin role", () => {
     expect(addAdminRoleSpy).toHaveBeenCalledWith([
       { discordRoleId: "discord role id", roleName: "Void Admin" },
     ]);
-    expect(editReplySpy).toHaveBeenCalledWith(
+    expect(followUpSpy).toHaveBeenCalledWith(
       "Scrim bot admin role <@&discord role id> added",
     );
   });

--- a/test/commands/admin/roles/remove-admin-role.test.ts
+++ b/test/commands/admin/roles/remove-admin-role.test.ts
@@ -1,5 +1,6 @@
 import {
   InteractionEditReplyOptions,
+  InteractionReplyOptions,
   Message,
   MessagePayload,
 } from "discord.js";
@@ -22,6 +23,11 @@ describe("Remove admin role", () => {
     [reply: string | InteractionEditReplyOptions | MessagePayload],
     string
   >;
+  let followUpSpy: SpyInstance<
+    Promise<Message<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
+    string
+  >;
 
   const mockAuthService = new AuthMock();
 
@@ -37,10 +43,14 @@ describe("Remove admin role", () => {
         }),
       },
       editReply: jest.fn(),
+      followUp: jest.fn(),
+      deleteReply: jest.fn(),
     } as unknown as CustomInteraction;
 
     editReplySpy = jest.spyOn(basicInteraction, "editReply");
     editReplySpy.mockClear();
+    followUpSpy = jest.spyOn(basicInteraction, "followUp");
+    followUpSpy.mockClear();
     removeAdminRoleSpy = jest.spyOn(mockAuthService, "removeAdminRoles");
     removeAdminRoleSpy.mockClear();
   });
@@ -49,7 +59,7 @@ describe("Remove admin role", () => {
     removeAdminRoleSpy.mockReturnValueOnce(Promise.resolve(["db id"]));
     await command.run(basicInteraction);
     expect(removeAdminRoleSpy).toHaveBeenCalledWith(["discord role id"]);
-    expect(editReplySpy).toHaveBeenCalledWith(
+    expect(followUpSpy).toHaveBeenCalledWith(
       "Scrim bot admin role <@&discord role id> removed",
     );
   });

--- a/test/commands/admin/scrim-crud/compute.test.ts
+++ b/test/commands/admin/scrim-crud/compute.test.ts
@@ -17,14 +17,14 @@ import { ComputeScrimCommand } from "../../../../src/commands/admin/scrim-crud/c
 describe("Close scrim", () => {
   let basicInteraction: CustomInteraction;
   let member: GuildMember;
-  let replySpy: SpyInstance<
-    Promise<InteractionResponse<boolean>>,
-    [reply: string | InteractionReplyOptions | MessagePayload],
-    string
-  >;
   let editReplySpy: SpyInstance<
     Promise<Message<boolean>>,
     [options: string | InteractionEditReplyOptions | MessagePayload],
+    string
+  >;
+  let followUpSpy: SpyInstance<
+    Promise<Message<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
     string
   >;
   let signupComputeScrimSpy: SpyInstance<
@@ -52,10 +52,12 @@ describe("Close scrim", () => {
       },
       reply: jest.fn(),
       editReply: jest.fn(),
+      followUp: jest.fn(),
+      deleteReply: jest.fn(),
       member,
     } as unknown as CustomInteraction;
-    replySpy = jest.spyOn(basicInteraction, "reply");
     editReplySpy = jest.spyOn(basicInteraction, "editReply");
+    followUpSpy = jest.spyOn(basicInteraction, "followUp");
     signupComputeScrimSpy = jest.spyOn(mockScrimSignups, "computeScrim");
     signupComputeScrimSpy.mockImplementation(() => {
       return Promise.resolve();
@@ -63,8 +65,8 @@ describe("Close scrim", () => {
   });
 
   beforeEach(() => {
-    replySpy.mockClear();
     editReplySpy.mockClear();
+    followUpSpy.mockClear();
     signupComputeScrimSpy.mockClear();
     command = new ComputeScrimCommand(
       new AuthMock() as AuthService,
@@ -79,7 +81,7 @@ describe("Close scrim", () => {
       "overstat.link",
       1,
     );
-    expect(editReplySpy).toHaveBeenCalledWith(
+    expect(followUpSpy).toHaveBeenCalledWith(
       "Scrim lobby successfully computed, you can now compute another lobby or close the scrim",
     );
     jest.useRealTimers();

--- a/test/commands/admin/scrim-crud/create.test.ts
+++ b/test/commands/admin/scrim-crud/create.test.ts
@@ -20,14 +20,14 @@ import { ChannelType } from "discord-api-types/v10";
 describe("Create scrim", () => {
   let basicInteraction: CustomInteraction;
   let member: GuildMember;
-  let replySpy: SpyInstance<
-    Promise<InteractionResponse<boolean>>,
-    [reply: string | InteractionReplyOptions | MessagePayload],
-    string
-  >;
   let editReplySpy: SpyInstance<
     Promise<Message<boolean>>,
     [options: string | InteractionEditReplyOptions | MessagePayload],
+    string
+  >;
+  let followUpSpy: SpyInstance<
+    Promise<Message<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
     string
   >;
   let signupsCreateScrimSpy: SpyInstance<
@@ -79,9 +79,11 @@ describe("Create scrim", () => {
       },
       reply: jest.fn(),
       editReply: jest.fn(),
+      followUp: jest.fn(),
+      deleteReply: jest.fn(),
       member,
     } as unknown as CustomInteraction;
-    replySpy = jest.spyOn(basicInteraction, "reply");
+    followUpSpy = jest.spyOn(basicInteraction, "followUp");
     editReplySpy = jest.spyOn(basicInteraction, "editReply");
     signupsCreateScrimSpy = jest.spyOn(mockScrimSignups, "createScrim");
     signupsCreateScrimSpy.mockImplementation(() => {
@@ -95,7 +97,7 @@ describe("Create scrim", () => {
   });
 
   beforeEach(() => {
-    replySpy.mockClear();
+    followUpSpy.mockClear();
     editReplySpy.mockClear();
     signupsCreateScrimSpy.mockClear();
     command = new CreateScrimCommand(
@@ -107,7 +109,7 @@ describe("Create scrim", () => {
 
   it("Should create scrim", async () => {
     await command.run(basicInteraction);
-    expect(editReplySpy).toHaveBeenCalledWith(
+    expect(followUpSpy).toHaveBeenCalledWith(
       "Scrim created. Channel: <#forum thread id>",
     );
     expect(channelCreatedSpy).toHaveBeenCalledWith(
@@ -134,11 +136,11 @@ describe("Create scrim", () => {
           },
           getChannel: () => ({ type: ChannelType.GuildText }),
         },
-        reply: jest.fn(),
+        editReply: jest.fn(),
       } as unknown as CustomInteraction;
-      replySpy = jest.spyOn(noChannelInteraction, "reply");
+      editReplySpy = jest.spyOn(noChannelInteraction, "editReply");
       await command.run(noChannelInteraction);
-      expect(replySpy).toHaveBeenCalledWith(
+      expect(editReplySpy).toHaveBeenCalledWith(
         "Scrim post could not be created. Channel provided is not a forum channel",
       );
       expect(signupsCreateScrimSpy).not.toHaveBeenCalled();

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -846,7 +846,7 @@ describe("DB connection", () => {
   describe("close and compute scrim", () => {
     const expectedDeleteQuery = `
       mutation {
-        delete_scrim_signups(where: { discord_channel: { _eq: "discord_channel_id" } }) {
+        delete_scrim_signups(where: { _or: [{ scrim_id: { _eq: "scrim_id_1" } }, { scrim_id: { _eq: "scrim_id_2" } }] }) {
           returning {
             id
           }
@@ -903,10 +903,10 @@ describe("DB connection", () => {
             update_scrims: {
               returning: [
                 {
-                  id: "7d3bc090-f9aa-4d74-a686-7ab198ab2dfe",
+                  id: "scrim_id_1",
                 },
                 {
-                  id: "9766e780-3c13-4298-8eed-a3cf9a206db4",
+                  id: "scrim_id_2",
                 },
               ],
             },

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -407,8 +407,8 @@ describe("Signups", () => {
       cache.setSignups(scrimId, []);
       jest
         .spyOn(dbMock, "closeScrim")
-        .mockImplementation((dbScrimId: string) => {
-          expect(dbScrimId).toEqual(scrimId);
+        .mockImplementation((discordChannelId: string) => {
+          expect(discordChannelId).toEqual(channelId);
           return Promise.resolve([scrimId]);
         });
 


### PR DESCRIPTION
* since all admin commands now get an immediate invisible reply, some commands now need visible followups, correct this oversight. 
* Fixed closeScrim bug where scrim signups wouldn't be deleted
* Skill is now a required input on `/compute-scrim`