### PR TITLE
Bugfix/date input

### DIFF
--- a/src/commands/admin/scrim-crud/create-scrim.ts
+++ b/src/commands/admin/scrim-crud/create-scrim.ts
@@ -11,7 +11,7 @@ import { isForumChannel } from "../../../utility/utility";
 
 export class CreateScrimCommand extends AdminCommand {
   inputNames = {
-    date: "date",
+    date: "datetime",
     name: "name",
     channel: "forum-channel",
   };

--- a/src/utility/time.ts
+++ b/src/utility/time.ts
@@ -51,12 +51,13 @@ const getDateString = (monthDay: string): string => {
     if (month === 1 && now.getMonth() >= 4) {
       year++;
     }
-  } else if (year) {
+  } else if (year < 100) {
     // yes this is disgusting but also there's no way this code is being used in 75 years
     year += 2000;
   }
   const monthString = String(month).padStart(2, "0");
   const dayString = String(day).padStart(2, "0");
+  console.log(monthDay, year);
   return `${year}-${monthString}-${dayString}`;
 };
 

--- a/test/commands/interaction.test.ts
+++ b/test/commands/interaction.test.ts
@@ -86,6 +86,14 @@ describe("Custom interaction", () => {
     expect(date).toEqual(new Date("2024-12-03T10:00:00-05:00"));
   });
 
+  it("Should set scrim date correctly when full year provided", async () => {
+    jest.setSystemTime(new Date("2025-02-12"));
+    dateTimeString = "02/12/2025 10 am";
+    const customInteraction = getCustomInteraction(basicInteraction);
+    const date = customInteraction.options.getDateTime("date");
+    expect(date).toEqual(new Date("2025-02-12T10:00:00-05:00"));
+  });
+
   it("Should set scrim for 12:30 pm", async () => {
     jest.setSystemTime(new Date("2024-12-2"));
     dateTimeString = "12/3 12:30 pm";


### PR DESCRIPTION
* Only add 2000 years to the date if its two digits
* switch argument name for /create-scrim date so its clear that it is asking for a date and a time