### PR TITLE
feature/scrim-pass

### DIFF
--- a/.github/workflows/pr-bump-version.yml
+++ b/.github/workflows/pr-bump-version.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.head_ref || github.ref_name }}
           sparse-checkout: |
             package.json
             package-lock.json

--- a/nhost/nhost/nhost.toml
+++ b/nhost/nhost/nhost.toml
@@ -166,6 +166,9 @@ interval = '1m'
 [postgres]
 version = '14.13-20240909-1'
 
+[postgres.resources.storage]
+capacity = 20
+
 [provider]
 
 [storage]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrim-bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrim-bot",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@nhost/nhost-js": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrim-bot",
   "description": "A multipurpose bot to track scrim signups, low prio and player performance among other things",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Jacob Heuman",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/commands/admin/scrim-crud/get-signups.ts
+++ b/src/commands/admin/scrim-crud/get-signups.ts
@@ -23,9 +23,13 @@ export class GetSignupsCommand extends AdminCommand {
     // the interaction gets voided and can't be used anymore.
     await interaction.editReply("Fetching teams, command in progress");
     const scrimPassRole = await interaction.guild?.roles.fetch(
-      "1344394308656300093",
+      "1345985586791579718",
+      // "1344394308656300093",
+      {
+        cache: true,
+        force: true,
+      },
     );
-    console.log(scrimPassRole);
     if (!scrimPassRole) {
       await interaction.editReply(
         "Can't fetch users with scrim pass from guild",

--- a/src/commands/admin/scrim-crud/get-signups.ts
+++ b/src/commands/admin/scrim-crud/get-signups.ts
@@ -22,12 +22,24 @@ export class GetSignupsCommand extends AdminCommand {
     // Discord only gives us 3 seconds to acknowledge an interaction before
     // the interaction gets voided and can't be used anymore.
     await interaction.editReply("Fetching teams, command in progress");
-
+    const scrimPassRole = await interaction.guild?.roles.fetch(
+      "1344394308656300093",
+    );
+    console.log(scrimPassRole);
+    if (!scrimPassRole) {
+      await interaction.editReply(
+        "Can't fetch users with scrim pass from guild",
+      );
+      return;
+    }
     const channelId = interaction.channelId;
 
     let channelSignups: { mainList: ScrimSignup[]; waitList: ScrimSignup[] };
     try {
-      channelSignups = await this.signupService.getSignups(channelId);
+      channelSignups = await this.signupService.getSignups(
+        channelId,
+        [...scrimPassRole.members].map((collectionItem) => collectionItem[0]),
+      );
     } catch (e) {
       await interaction.editReply(`Could not fetch signups. ${e}`);
       return;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -39,7 +39,7 @@ export const commands: Command[] = [
   new RemoveAdminRoleCommand(authService),
 
   new CreateScrimCommand(authService, signupsService, staticValueService),
-  new GetSignupsCommand(authService, signupsService),
+  new GetSignupsCommand(authService, signupsService, staticValueService),
   new ComputeScrimCommand(authService, signupsService),
   new CloseScrimCommand(authService, signupsService),
 

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -5,6 +5,8 @@ import {
   DbTable,
   DbValue,
   Expression,
+  ExtractReturnType,
+  FieldSelection,
   JSONValue,
   LogicalExpression,
 } from "./types";
@@ -12,11 +14,12 @@ import { DiscordRole } from "../models/Role";
 import { ExpungedPlayerPrio } from "../models/Prio";
 
 export abstract class DB {
-  abstract get<K extends string>(
+  abstract get<K extends FieldSelection[]>(
     tableName: DbTable,
     logicalExpression: LogicalExpression | undefined,
-    fieldsToReturn: K[],
-  ): Promise<Array<Record<K, DbValue>>>;
+    fieldsToReturn: K,
+  ): Promise<Array<ExtractReturnType<K>>>;
+
   abstract update<K extends string>(
     tableName: DbTable,
     logicalExpression: LogicalExpression,
@@ -425,11 +428,11 @@ export abstract class DB {
           },
         ],
       },
-      ["player_id", "amount", "discord_id", "reason"],
+      [{ player: ["discord_id", "id"] }, "amount", "reason"],
     );
-    return dbData.map(({ player_id, discord_id, amount, reason }) => ({
-      id: player_id as string,
-      discordId: discord_id as string,
+    return dbData.map(({ player, amount, reason }) => ({
+      id: player.id as string,
+      discordId: player.discord_id as string,
       amount: amount as number,
       reason: reason as string,
     }));

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -405,7 +405,9 @@ export abstract class DB {
 
   async getPrio(
     date: Date,
-  ): Promise<{ id: string; amount: number; reason: string }[]> {
+  ): Promise<
+    { id: string; discordId: string; amount: number; reason: string }[]
+  > {
     const dbData = await this.get(
       DbTable.prio,
       {
@@ -423,10 +425,11 @@ export abstract class DB {
           },
         ],
       },
-      ["player_id", "amount", "reason"],
+      ["player_id", "amount", "discord_id", "reason"],
     );
-    return dbData.map(({ player_id, amount, reason }) => ({
+    return dbData.map(({ player_id, discord_id, amount, reason }) => ({
       id: player_id as string,
+      discordId: discord_id as string,
       amount: amount as number,
       reason: reason as string,
     }));

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -29,6 +29,18 @@ export enum DbTable {
   staticKeyValues = "static_key_value",
 }
 
+// Recursive type to infer the return structure
+export type FieldSelection = string | { [key: string]: FieldSelection[] };
+
+// Recursive type to infer return type from FieldSelection
+export type ExtractReturnType<T extends FieldSelection[]> = {
+  [K in T[number] as K extends string ? K : keyof K]: K extends string
+    ? DbValue
+    : K extends Record<string, FieldSelection[]>
+      ? ExtractReturnType<K[keyof K]> // 🔥 Flattening the nesting
+      : never;
+};
+
 export function isCompoundExpression(
   value: LogicalExpression,
 ): value is CompoundExpression {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,17 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { GatewayIntentBits } from "discord.js";
+import { Events, GatewayIntentBits } from "discord.js";
 import ExtendedClient from "./ExtendedClient";
 import { commands } from "./commands";
 import { appConfig } from "./config";
 
-const client = new ExtendedClient({ intents: [GatewayIntentBits.Guilds] });
+const client = new ExtendedClient({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildPresences,
+    GatewayIntentBits.GuildMembers,
+  ],
+});
 
 for (const command of commands) {
   client.commands.set(command.name, command);

--- a/src/models/Prio.ts
+++ b/src/models/Prio.ts
@@ -1,7 +1,12 @@
-// a map of playerId -> accumulated prio
+// a map of player.discordId -> accumulated prio
 export type PlayerMap = Map<string, { amount: number; reason: string }>;
 // a player id and its associated prio
-export type PlayerPrio = { id: string; amount: number; reason: string };
+export type PlayerPrio = {
+  id: string;
+  discordId: string;
+  amount: number;
+  reason: string;
+};
 // a player discord id, with amount and endDate
 export type ExpungedPlayerPrio = {
   playerDiscordId: string;

--- a/src/services/prio.ts
+++ b/src/services/prio.ts
@@ -136,12 +136,18 @@ export class PrioService {
     playerMap: PlayerMap,
   ) {
     for (const team of teams) {
-      let prio = 0;
+      let containsHighPrio = false;
+      let containsLowPrio = false;
       const reason: string[] = [];
       team.players.forEach((player) => {
         const playerPrioEntry = playerMap.get(player.discordId);
         if (playerPrioEntry) {
-          prio += playerPrioEntry.amount;
+          containsHighPrio = containsHighPrio
+            ? containsHighPrio
+            : playerPrioEntry.amount > 0;
+          containsLowPrio = containsLowPrio
+            ? containsLowPrio
+            : playerPrioEntry.amount < 0;
           reason.push(`${player.displayName}: ${playerPrioEntry.reason}`);
           player.prio = {
             amount: playerPrioEntry.amount,
@@ -149,8 +155,15 @@ export class PrioService {
           };
         }
       });
+      // Per sly, prio does not stack. Anyone on low prio overrides whole team to be on low prio
+      let amount = 0;
+      if (containsLowPrio) {
+        amount = -1;
+      } else if (containsHighPrio) {
+        amount = 1;
+      }
       team.prio = {
-        amount: prio,
+        amount,
         reasons: reason.join("; "),
       };
     }

--- a/src/services/prio.ts
+++ b/src/services/prio.ts
@@ -29,12 +29,12 @@ export class PrioService {
   async getTeamPrioForScrim(
     scrim: Scrim,
     teams: ScrimSignup[],
-    usersWithScrimPass: User[],
+    discordIdsWithScrimPass: string[],
   ): Promise<ScrimSignup[]> {
     const playersWithPrio = await this.db.getPrio(scrim.dateTime);
     const playerMap = this.generatePlayerMap(
       playersWithPrio,
-      usersWithScrimPass,
+      discordIdsWithScrimPass,
     );
     this.setTeamPrioFromPlayerPrio(teams, playerMap);
     return teams;
@@ -93,7 +93,7 @@ export class PrioService {
 
   private generatePlayerMap(
     playersIdsWithPrio: PlayerPrio[],
-    usersWithScrimPass: User[],
+    discordIdsWithScrimPass: string[],
   ): PlayerMap {
     const playerMap: Map<string, { amount: number; reason: string }> =
       new Map();
@@ -114,16 +114,15 @@ export class PrioService {
     }
 
     // we only add scrim pass prio if they do not have low prio
-    // use discordUser.id here to match it with the discordId of players above
-    for (const user of usersWithScrimPass) {
-      const playerPrio = playerMap.get(user.id);
+    for (const id of discordIdsWithScrimPass) {
+      const playerPrio = playerMap.get(id);
       if (!playerPrio) {
-        playerMap.set(user.id, {
+        playerMap.set(id, {
           amount: 1,
           reason: "Scrim pass",
         });
       } else if (playerPrio.amount > 0) {
-        playerMap.set(user.id, {
+        playerMap.set(id, {
           amount: playerPrio.amount + 1,
           reason: playerPrio.reason + ", " + "Scrim pass",
         });

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -171,7 +171,7 @@ export class ScrimSignups {
 
   async getSignups(
     discordChannelID: string,
-    usersWithScrimPass?: User[],
+    discordIdsWithScrimPass?: string[],
   ): Promise<{ mainList: ScrimSignup[]; waitList: ScrimSignup[] }> {
     const scrim = this.cache.getScrim(discordChannelID);
     if (!scrim) {
@@ -187,7 +187,7 @@ export class ScrimSignups {
     const prioTeams = await this.prioService.getTeamPrioForScrim(
       scrim,
       teams,
-      usersWithScrimPass ?? [],
+      discordIdsWithScrimPass ?? [],
     );
     this.cache.setSignups(scrim.id, prioTeams);
     return this.sortTeams(teams);

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -171,6 +171,7 @@ export class ScrimSignups {
 
   async getSignups(
     discordChannelID: string,
+    usersWithScrimPass?: User[],
   ): Promise<{ mainList: ScrimSignup[]; waitList: ScrimSignup[] }> {
     const scrim = this.cache.getScrim(discordChannelID);
     if (!scrim) {
@@ -183,7 +184,11 @@ export class ScrimSignups {
         ScrimSignups.convertDbToScrimSignup(signupData);
       teams.push(teamData);
     }
-    const prioTeams = await this.prioService.getTeamPrioForScrim(scrim, teams);
+    const prioTeams = await this.prioService.getTeamPrioForScrim(
+      scrim,
+      teams,
+      usersWithScrimPass ?? [],
+    );
     this.cache.setSignups(scrim.id, prioTeams);
     return this.sortTeams(teams);
   }

--- a/src/services/static-values.ts
+++ b/src/services/static-values.ts
@@ -3,6 +3,7 @@ import { DbTable } from "../db/types";
 
 export class StaticValueService {
   private instructionText: string | undefined;
+  private scrimPassRoleId: string | undefined;
 
   constructor(private db: DB) {}
 
@@ -10,16 +11,28 @@ export class StaticValueService {
     if (this.instructionText) {
       return this.instructionText;
     }
+    this.instructionText = await this.fetchValue("signups_instruction_text");
+    return this.instructionText;
+  }
+
+  async getScrimPassRoleId(): Promise<string | undefined> {
+    if (this.scrimPassRoleId) {
+      return this.scrimPassRoleId;
+    }
+    this.scrimPassRoleId = await this.fetchValue("scrim_pass_role_id");
+    return this.scrimPassRoleId;
+  }
+
+  private async fetchValue(key: string): Promise<string | undefined> {
     const dbResult = await this.db.get(
       DbTable.staticKeyValues,
       {
         fieldName: "name",
-        value: "signups_instruction_text",
+        value: key,
         comparator: "eq",
       },
       ["value"],
     );
-    this.instructionText = dbResult[0].value as string;
-    return this.instructionText;
+    return dbResult[0]?.value as string;
   }
 }

--- a/test/commands/admin/scrim-crud/get.test.ts
+++ b/test/commands/admin/scrim-crud/get.test.ts
@@ -17,6 +17,8 @@ import { ScrimSignupMock } from "../../../mocks/signups.mock";
 import { ScrimSignups } from "../../../../src/services/signups";
 import { GetSignupsCommand } from "../../../../src/commands/admin/scrim-crud/get-signups";
 import { ScrimSignup } from "../../../../src/models/Scrims";
+import { StaticValueServiceMock } from "../../../mocks/static-values.mock";
+import { StaticValueService } from "../../../../src/services/static-values";
 
 describe("Get signups", () => {
   let basicInteraction: CustomInteraction;
@@ -100,6 +102,7 @@ describe("Get signups", () => {
   let command: GetSignupsCommand;
 
   const mockScrimSignups = new ScrimSignupMock();
+  const mockStaticValueService = new StaticValueServiceMock();
 
   beforeAll(() => {
     basicInteraction = {
@@ -124,7 +127,7 @@ describe("Get signups", () => {
       });
     });
     const guild: Guild = basicInteraction.guild as Guild;
-    // @ts-ignore its trying to match the incorrect method
+    // @ts-expect-error its trying to match the incorrect method
     getMembersWithScrimPassRoleSpy = jest.spyOn(guild.roles, "fetch");
     getMembersWithScrimPassRoleSpy.mockReturnValue(
       Promise.resolve({ members: [] } as unknown as Role),
@@ -136,16 +139,27 @@ describe("Get signups", () => {
     followupSpy.mockClear();
     editReplySpy.mockClear();
     getSignupsSpy.mockClear();
+    getMembersWithScrimPassRoleSpy.mockClear();
     command = new GetSignupsCommand(
       new AuthMock() as AuthService,
       mockScrimSignups as unknown as ScrimSignups,
+      mockStaticValueService as unknown as StaticValueService,
     );
   });
 
   it("Should get signups", async () => {
     jest.useFakeTimers();
+    getMembersWithScrimPassRoleSpy.mockReturnValueOnce(
+      Promise.resolve({
+        members: [["an id", { id: "an id" }]],
+      } as unknown as Role),
+    );
     await command.run(basicInteraction);
-    expect(getSignupsSpy).toHaveBeenCalledWith("forum thread id", []);
+    expect(getMembersWithScrimPassRoleSpy).toHaveBeenCalledWith("3568173514", {
+      cache: true,
+      force: true,
+    });
+    expect(getSignupsSpy).toHaveBeenCalledWith("forum thread id", ["an id"]);
     const expectedMainListString = `Main list.\n__Main list team__. Signed up by: <@teamCapDiscordId1>. Players: <@teamCapDiscordId1> <@teamCapDiscordId1>. Prio: 1. League prio.\n__Main list team 2__. Signed up by: <@teamCapDiscordId2>. Players: .\n`;
     const expectedWaitListString = `Wait list.\n__Wait list team__. Signed up by: <@teamCapDiscordId3>. Players: . Prio: -1. Team captain is a known inter.\n`;
     expect(followupSpy).toHaveBeenCalledWith({
@@ -160,6 +174,37 @@ describe("Get signups", () => {
     jest.useRealTimers();
   });
 
+  it("should get signups but reply with error because theres no scrim pass role id in the db", async () => {
+    if (!basicInteraction.guild) {
+      expect(true).toBeFalsy();
+      return;
+    }
+    getMembersWithScrimPassRoleSpy.mockReturnValueOnce(Promise.resolve(null));
+    jest
+      .spyOn(mockStaticValueService, "getScrimPassRoleId")
+      .mockReturnValueOnce(Promise.resolve(undefined));
+
+    await command.run(basicInteraction);
+    expect(editReplySpy).toHaveBeenCalledWith(
+      "Unable to get scrim pass role id from db",
+    );
+    expect(getSignupsSpy).toHaveBeenCalledWith("forum thread id", []);
+  });
+
+  it("should get signups but reply with error because the guild is not defined", async () => {
+    if (!basicInteraction.guild) {
+      expect(true).toBeFalsy();
+      return;
+    }
+    getMembersWithScrimPassRoleSpy.mockReturnValueOnce(Promise.resolve(null));
+
+    await command.run(basicInteraction);
+    expect(editReplySpy).toHaveBeenCalledWith(
+      "Can't fetch scrim pass role members from discord",
+    );
+    expect(getSignupsSpy).toHaveBeenCalledWith("forum thread id", []);
+  });
+
   describe("errors", () => {
     it("should not get signups because the signup service threw an exception", async () => {
       getSignupsSpy.mockImplementation(() => {
@@ -169,19 +214,6 @@ describe("Get signups", () => {
       await command.run(basicInteraction);
       expect(editReplySpy).toHaveBeenCalledWith(
         "Could not fetch signups. Error: No scrim found for that channel",
-      );
-    });
-
-    it("should not get signups because the guild is not defined", async () => {
-      if (!basicInteraction.guild) {
-        expect(true).toBeFalsy();
-        return;
-      }
-      getMembersWithScrimPassRoleSpy.mockReturnValueOnce(Promise.resolve(null));
-
-      await command.run(basicInteraction);
-      expect(editReplySpy).toHaveBeenCalledWith(
-        "Can't fetch users with scrim pass from guild",
       );
     });
   });

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -1118,7 +1118,10 @@ describe("DB connection", () => {
       const expected = `
       query {
         prio(where: { _and: [{ start_date: { _lte: "${scrimDate.toISOString()}" } }, { end_date: { _gte: "${scrimDate.toISOString()}" } }] }) {
-          player_id
+          player {
+            discord_id
+            id
+          }
           amount
           reason
         }
@@ -1129,9 +1132,12 @@ describe("DB connection", () => {
         data: {
           prio: [
             {
-              player_id: "c79f4607-2343-465a-94e4-f99e63ab7602",
-              amount: -400,
-              reason: "Enemy of the people",
+              player: {
+                id: "4d47ddfc-9773-4df2-9b59-35f55212535d",
+                discord_id: "675854726251675700",
+              },
+              amount: -5,
+              reason: "Rude to staff",
             },
           ],
         },
@@ -1141,9 +1147,10 @@ describe("DB connection", () => {
     const prioPlayers = await nhostDb.getPrio(scrimDate);
     expect(prioPlayers).toEqual([
       {
-        id: "c79f4607-2343-465a-94e4-f99e63ab7602",
-        amount: -400,
-        reason: "Enemy of the people",
+        id: "4d47ddfc-9773-4df2-9b59-35f55212535d",
+        discordId: "675854726251675700",
+        amount: -5,
+        reason: "Rude to staff",
       },
     ]);
   });

--- a/test/mocks/db.mock.ts
+++ b/test/mocks/db.mock.ts
@@ -145,12 +145,15 @@ export class DbMock extends DB {
 
   async getPrio(
     date: Date,
-  ): Promise<{ id: string; amount: number; reason: string }[]> {
+  ): Promise<
+    { id: string; discordId: string; amount: number; reason: string }[]
+  > {
     return Promise.resolve([
       {
         id: "0",
         amount: 0,
         reason: "lol",
+        discordId: "id",
       },
     ]);
   }

--- a/test/mocks/db.mock.ts
+++ b/test/mocks/db.mock.ts
@@ -1,5 +1,11 @@
 import { DB } from "../../src/db/db";
-import { DbValue, JSONValue, LogicalExpression } from "../../src/db/types";
+import {
+  DbValue,
+  ExtractReturnType,
+  FieldSelection,
+  JSONValue,
+  LogicalExpression,
+} from "../../src/db/types";
 import { PlayerInsert } from "../../src/models/Player";
 import { ScrimSignupsWithPlayers } from "../../src/db/table.interfaces";
 
@@ -32,13 +38,13 @@ export class DbMock extends DB {
     return Promise.resolve(this.deleteResponse);
   }
 
-  get<K extends string>(
+  get<K extends FieldSelection[]>(
     tableName: string,
     fieldsToSearch: LogicalExpression,
-    fieldsToReturn: K[],
-  ): Promise<Array<Record<K, DbValue>>> {
+    fieldsToReturn: K,
+  ): Promise<Array<ExtractReturnType<K>>> {
     return Promise.resolve([{ id: "" }] as unknown as Array<
-      Record<K, DbValue>
+      ExtractReturnType<K>
     >);
   }
 

--- a/test/mocks/prio.mock.ts
+++ b/test/mocks/prio.mock.ts
@@ -32,8 +32,14 @@ export class PrioServiceMock {
   async getTeamPrioForScrim(
     scrim: Scrim,
     teams: ScrimSignup[],
+    usersWithScrimPass: User[],
   ): Promise<ScrimSignup[]> {
-    console.log("Getting team prio in prio mock", scrim, teams);
+    console.log(
+      "Getting team prio in prio mock",
+      scrim,
+      teams,
+      usersWithScrimPass,
+    );
     return [];
   }
 }

--- a/test/mocks/prio.mock.ts
+++ b/test/mocks/prio.mock.ts
@@ -32,13 +32,13 @@ export class PrioServiceMock {
   async getTeamPrioForScrim(
     scrim: Scrim,
     teams: ScrimSignup[],
-    usersWithScrimPass: User[],
+    discordIdsWithScrimPass: string[],
   ): Promise<ScrimSignup[]> {
     console.log(
       "Getting team prio in prio mock",
       scrim,
       teams,
-      usersWithScrimPass,
+      discordIdsWithScrimPass,
     );
     return [];
   }

--- a/test/mocks/static-values.mock.ts
+++ b/test/mocks/static-values.mock.ts
@@ -2,4 +2,7 @@ export class StaticValueServiceMock {
   async getInstructionText(): Promise<string | undefined> {
     return "Scrim date: ${scrimTime}\nDraft time: ${draftTime}\nLobby post time: ${lobbyPostTime}\nLow prio time: ${lowPrioTime}\nscrim signup instruction text";
   }
+  async getScrimPassRoleId(): Promise<string | undefined> {
+    return "3568173514";
+  }
 }

--- a/test/services/prio.test.ts
+++ b/test/services/prio.test.ts
@@ -155,9 +155,14 @@ describe("Prio", () => {
           displayName: "free agent",
           id: "3",
         };
+        const scrimPassHolder: Player = {
+          discordId: "on team discord id 4",
+          displayName: "Rich boi",
+          id: "4",
+        };
         const team: ScrimSignup = {
           date: today,
-          players: [lowPrioPlayerOnTeam, highPrioPlayerOnTeam],
+          players: [lowPrioPlayerOnTeam, highPrioPlayerOnTeam, scrimPassHolder],
           signupId: "",
           signupPlayer: {
             id: "",
@@ -197,15 +202,23 @@ describe("Prio", () => {
             },
           ]),
         );
-        const prioTeams = await prioService.getTeamPrioForScrim(
-          scrim,
-          teams,
-          [],
-        );
+        const prioTeams = await prioService.getTeamPrioForScrim(scrim, teams, [
+          scrimPassHolder.discordId,
+          lowPrioPlayerOnTeam.discordId,
+        ]);
+        // team should have
+        //   +2 prio from the high prio player since they have two +1 prio entries
+        //   +1 prio from the scrim pass holder
+        //   -1 prio from the low prio player (They have a scrim pass but that is ignored when they have low prio)
+        // For a total of +2 prio
         expect(prioTeams).toEqual([
           {
             date: today,
-            players: [lowPrioPlayerOnTeam, highPrioPlayerOnTeam],
+            players: [
+              lowPrioPlayerOnTeam,
+              highPrioPlayerOnTeam,
+              scrimPassHolder,
+            ],
             signupId: "",
             signupPlayer: {
               id: "",
@@ -214,8 +227,9 @@ describe("Prio", () => {
             },
             teamName: "",
             prio: {
-              amount: 1,
-              reasons: "Bad Boi: bad boi; Good Boi: good boi, good boi",
+              amount: 2,
+              reasons:
+                "Bad Boi: bad boi; Good Boi: good boi, good boi; Rich boi: Scrim pass",
             },
           },
         ]);

--- a/test/services/prio.test.ts
+++ b/test/services/prio.test.ts
@@ -135,7 +135,7 @@ describe("Prio", () => {
     describe("correctly set prio", () => {
       beforeEach(() => {});
 
-      it("should set prio for teams from its players", async () => {
+      it("should set low prio for teams from its players", async () => {
         const today = new Date();
         const scrim: Scrim = {
           dateTime: today,
@@ -211,6 +211,7 @@ describe("Prio", () => {
         //   +1 prio from the scrim pass holder
         //   -1 prio from the low prio player (They have a scrim pass but that is ignored when they have low prio)
         // For a total of +2 prio
+        // but with Sly's override one low prio player overrides the whole squad, so -1
         expect(prioTeams).toEqual([
           {
             date: today,
@@ -227,9 +228,91 @@ describe("Prio", () => {
             },
             teamName: "",
             prio: {
-              amount: 2,
+              amount: -1,
               reasons:
                 "Bad Boi: bad boi; Good Boi: good boi, good boi; Rich boi: Scrim pass",
+            },
+          },
+        ]);
+      });
+      it("should set high prio for teams from its players", async () => {
+        const today = new Date();
+        const scrim: Scrim = {
+          dateTime: today,
+        } as Scrim;
+        const highPrioPlayerOnTeam: Player = {
+          discordId: "on team discord id 2",
+          displayName: "Good Boi",
+          id: "2",
+        };
+        const lowPrioPlayerFreeAgent: Player = {
+          discordId: "free agent discord id",
+          displayName: "free agent",
+          id: "3",
+        };
+        const scrimPassHolder: Player = {
+          discordId: "on team discord id 4",
+          displayName: "Rich boi",
+          id: "4",
+        };
+        const team: ScrimSignup = {
+          date: today,
+          players: [highPrioPlayerOnTeam, scrimPassHolder],
+          signupId: "",
+          signupPlayer: {
+            id: "",
+            discordId: "",
+            displayName: "",
+          },
+          teamName: "",
+        };
+        const teams = [team];
+        const dbSpy = jest.spyOn(dbMock, "getPrio");
+        dbSpy.mockReturnValue(
+          // return low prio for 1, and two high prio ticks for another, also return low prio for someone not participating in the scrim
+          Promise.resolve([
+            {
+              id: highPrioPlayerOnTeam.id,
+              discordId: highPrioPlayerOnTeam.discordId,
+              amount: 1,
+              reason: "good boi",
+            },
+            {
+              id: highPrioPlayerOnTeam.id,
+              discordId: highPrioPlayerOnTeam.discordId,
+              amount: 1,
+              reason: "good boi",
+            },
+            {
+              id: lowPrioPlayerFreeAgent.id,
+              discordId: lowPrioPlayerFreeAgent.discordId,
+              amount: -400,
+              reason: "SMH Tried to nuke the entire server",
+            },
+          ]),
+        );
+        const prioTeams = await prioService.getTeamPrioForScrim(scrim, teams, [
+          scrimPassHolder.discordId,
+        ]);
+        // team should have
+        //   +2 prio from the high prio player since they have two +1 prio entries
+        //   +1 prio from the scrim pass holder
+        // For a total of +3 prio
+        // but with Sly's override one prios do not stack so only +1
+        expect(prioTeams).toEqual([
+          {
+            date: today,
+            players: [highPrioPlayerOnTeam, scrimPassHolder],
+            signupId: "",
+            signupPlayer: {
+              id: "",
+              discordId: "",
+              displayName: "",
+            },
+            teamName: "",
+            prio: {
+              amount: 1,
+              reasons: "Good Boi: good boi, good boi; Rich boi: Scrim pass",
             },
           },
         ]);

--- a/test/services/prio.test.ts
+++ b/test/services/prio.test.ts
@@ -1,9 +1,8 @@
-import { GuildMember, User } from "discord.js";
+import { User } from "discord.js";
 import { Player, PlayerInsert } from "../../src/models/Player";
 import { PrioService } from "../../src/services/prio";
 import { DbMock } from "../mocks/db.mock";
 import { CacheService } from "../../src/services/cache";
-import { AuthService } from "../../src/services/auth";
 import SpyInstance = jest.SpyInstance;
 import { Scrim, ScrimSignup } from "../../src/models/Scrims";
 
@@ -172,17 +171,37 @@ describe("Prio", () => {
         dbSpy.mockReturnValue(
           // return low prio for 1, and two high prio ticks for another, also return low prio for someone not participating in the scrim
           Promise.resolve([
-            { id: lowPrioPlayerOnTeam.id, amount: -1, reason: "bad boi" },
-            { id: highPrioPlayerOnTeam.id, amount: 1, reason: "good boi" },
-            { id: highPrioPlayerOnTeam.id, amount: 1, reason: "good boi" },
+            {
+              id: lowPrioPlayerOnTeam.id,
+              discordId: lowPrioPlayerOnTeam.discordId,
+              amount: -1,
+              reason: "bad boi",
+            },
+            {
+              id: highPrioPlayerOnTeam.id,
+              discordId: highPrioPlayerOnTeam.discordId,
+              amount: 1,
+              reason: "good boi",
+            },
+            {
+              id: highPrioPlayerOnTeam.id,
+              discordId: highPrioPlayerOnTeam.discordId,
+              amount: 1,
+              reason: "good boi",
+            },
             {
               id: lowPrioPlayerFreeAgent.id,
+              discordId: lowPrioPlayerFreeAgent.discordId,
               amount: -400,
               reason: "SMH Tried to nuke the entire server",
             },
           ]),
         );
-        const prioTeams = await prioService.getTeamPrioForScrim(scrim, teams);
+        const prioTeams = await prioService.getTeamPrioForScrim(
+          scrim,
+          teams,
+          [],
+        );
         expect(prioTeams).toEqual([
           {
             date: today,


### PR DESCRIPTION
* users with a role specified in the db are given priority
* Individual prio no longer stacks, player with low prio has low prio no matter other prio entries
* Team prio no longer stacks
  * teams with one player on low prio have low prio
  * teams with one player on high prio have same prio has team with multiple players on high prio
* update nhost toml because cli update was released
* db.get can now take a nested object for the return field
* bump version workflow now checks out branch instead of pr ref