### PR TITLE
feature/require-overstat

### DIFF
--- a/.github/workflows/pr-bump-version.yml
+++ b/.github/workflows/pr-bump-version.yml
@@ -34,7 +34,7 @@ jobs:
           user: bot
       - name : Bump version
         env:
-          TITLE: ${{ github.event.pull_request.title }}
+          TITLE: ${{ inputs.increment-type || github.event.pull_request.title }}
         run: |
           npm run bump-version $TITLE
           git push

--- a/README.md
+++ b/README.md
@@ -23,39 +23,41 @@ The file should contain:
   "dev": {
     "lobbySize": 3,
     "discord": {
-      "token": "BOT_TOKEN",
+      "token": "DEV_DISCORD_BOT_TOKEN",
       "clientId": "DEV_DISCORD_CLIENT_ID",
       "guildId": "DEV_DISCORD_GUILD_ID"  
     },
     "nhost": {
-      "adminSecret": "LOCAL_ADMIN_SECRET",
-      "subdomain": "local_subdomain",
-      "region": "local_region"
+      "adminSecret": "nhost-admin-secret",
+      "subdomain": "local",
+      "region": "local"
     }
   },
   "prod": {
     "lobbySize": 20,
     "discord": {
-      "token": "BOT_TOKEN",
+      "token": "DISCORD_BOT_TOKEN",
       "clientId": "DISCORD_CLIENT_ID",
       "guildId": "DISCORD_GUILD_ID"
     },
     "nhost": {
-      "adminSecret": "ADMIN_SECRET",
-      "subdomain": "subdomain",
-      "region": "region"
+      "adminSecret": "NHOST_SECRET",
+      "subdomain": "NHOST_SUBDOMAIN",
+      "region": "NHOST_REGION"
     }
   }
 }
 ```
-Where BOT_TOKEN is the bot token taken from the discord application portal bot page
+Where DISCORD_BOT_TOKEN is the bot token taken from the discord application portal bot page
 DISCORD_CLIENT_ID is the application ID from the discord application portal general information page
 DISCORD_GUILD_ID is the server ID of the server the bot is running in
 
-You can create a template config file by running 
+You can create a template config file by running
 `
 npm run create-config
 `
+This script will default to generic placeholders but can use environment variables of the same names to populate the values. 
+The script will warn you which variables are missing and you can re run it to get the correct values.
 
 Then you can run tests with 
 
@@ -64,9 +66,11 @@ Then you can run tests with
 ### Commands
 All commands are in the commands directory and further information can be found in the README in that directory
 
-They depend on services in the services/ directory that use the
+They depend on services in the services/ directory
 
 ## Deploying
+
+The `main` branch is tracked by heroku and automatically deploys.
 
 ### Test commands on a server
 
@@ -75,23 +79,19 @@ https://docs.nhost.io/development/cli/getting-started
 
 Start nhost by going to the nhost/ directory and running `nhost up --apply-seeds`, you can then navigate to the dashboard link the command gives you to see that its running correctly
 
-Before deploying test your new or updated commands on a private discord server, update your config.json file dev property with that servers discord info and insert necessary date into nhost (scrim_admin_roles and static_key_values.signup_channel).
+Before merge to main, test your new or updated commands on a private discord server, update your config.json file dev property with that servers discord info and insert necessary data into nhost (scrim_admin_roles and static_key_values.signup_channel).
 
 Deploy commands to your private server with `npm run deploy-commands`
 
 The bot can use hot reloads `npm run start:watch` or you can run it normally from the dist folder with `npm run start` (make sure to build first)
 
 ### Deploy to prod
-After you verify everything is in working order you can run the prod deploy and start scripts
 
-```sh
-npm run deploy-commands:prod
-```
-
-Then you can run the production script with 
-```sh
-npm run start:prod
-```
+After merge to main heroku will automatically start a new build. This build consists of 
+* `heroku-prebuild` script in package.json, heroku has secrets as env variables so they are auto populated by the script
+* Then runs `npm install` and `npm run build` automatically,
+* Then runs the worker specified in the `Procfile`
+* Finally it runs the release task in the same Procfile to deploy the commands.
 
 ## Install on discord server:
 

--- a/scripts/create-config.sh
+++ b/scripts/create-config.sh
@@ -23,14 +23,14 @@ cat > $file_location <<EOF
   "dev": {
     "lobbySize": 3,
     "discord": {
-      "token": "BOT_TOKEN",
-      "clientId": "DISCORD_CLIENT_ID",
-      "guildId": "DISCORD_GUILD_ID"
+      "token": "DEV_DISCORD_BOT_TOKEN",
+      "clientId": "DEV_DISCORD_CLIENT_ID",
+      "guildId": "DEV_DISCORD_GUILD_ID"
     },
     "nhost": {
-      "adminSecret": "nhost admin secret",
-      "subdomain": "subdomain",
-      "region": "region"
+      "adminSecret": "nhost-admin-secret",
+      "subdomain": "local",
+      "region": "local"
     }
   },
   "prod": {

--- a/src/commands/signup/sign-up.ts
+++ b/src/commands/signup/sign-up.ts
@@ -25,16 +25,30 @@ export class SignupCommand extends MemberCommand {
     const player3 = interaction.options.getUser("player3", true);
     await interaction.reply("Fetched all input, working on request");
 
+    const overstatRequiredDeadline = new Date(1742799600);
+
     try {
-      const signupId = await this.signupService.addTeam(
+      const signup = await this.signupService.addTeam(
         channelId as string,
         teamName,
         signupPlayer,
         [player1, player2, player3],
       );
       await interaction.editReply(
-        `Team ${teamName} signed up with players: <@${player1.id}>, <@${player2.id}>, <@${player3.id}>, signed up by <@${signupPlayer.id}>. Signup id: ${signupId}`,
+        `${teamName}\n<@${player1.id}>, <@${player2.id}>, <@${player3.id}>\nSigned up by <@${signupPlayer.id}>.\n${signup.signupId}`,
       );
+      const warnings = [];
+      for (const player of signup.players) {
+        if (!player.overstatId) {
+          warnings.push(`${player.displayName} is missing overstat id.`);
+        }
+      }
+      if (warnings.length > 0) {
+        await interaction.followUp({
+          content: `${warnings.join("\n")}\nScrims starting on ${this.formatDate(overstatRequiredDeadline)} will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376`,
+          ephemeral: true,
+        });
+      }
     } catch (error) {
       await interaction.editReply("Team not signed up. " + error);
       return;

--- a/src/commands/signup/sign-up.ts
+++ b/src/commands/signup/sign-up.ts
@@ -25,7 +25,7 @@ export class SignupCommand extends MemberCommand {
     const player3 = interaction.options.getUser("player3", true);
     await interaction.reply("Fetched all input, working on request");
 
-    const overstatRequiredDeadline = new Date(1742799600);
+    const overstatRequiredDeadline = new Date(1742799600000);
 
     try {
       const signup = await this.signupService.addTeam(

--- a/src/commands/signup/sign-up.ts
+++ b/src/commands/signup/sign-up.ts
@@ -45,7 +45,7 @@ export class SignupCommand extends MemberCommand {
       }
       if (warnings.length > 0) {
         await interaction.followUp({
-          content: `${warnings.join("\n")}\nScrims starting on ${this.formatDate(overstatRequiredDeadline)} will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376`,
+          content: `${warnings.join("\n")}\nScrims starting after ${this.formatDate(overstatRequiredDeadline)} will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376`,
           ephemeral: true,
         });
       }

--- a/src/commands/signup/sign-up.ts
+++ b/src/commands/signup/sign-up.ts
@@ -1,6 +1,7 @@
 import { MemberCommand } from "../command";
 import { CustomInteraction } from "../interaction";
 import { ScrimSignups } from "../../services/signups";
+import { isGuildMember } from "../../utility/utility";
 
 export class SignupCommand extends MemberCommand {
   constructor(private signupService: ScrimSignups) {
@@ -19,10 +20,17 @@ export class SignupCommand extends MemberCommand {
   async run(interaction: CustomInteraction) {
     const channelId = interaction.channelId;
     const teamName = interaction.options.getString("teamname", true);
-    const signupPlayer = interaction.user;
+    const signupPlayer = interaction.member;
     const player1 = interaction.options.getUser("player1", true);
     const player2 = interaction.options.getUser("player2", true);
     const player3 = interaction.options.getUser("player3", true);
+
+    if (!isGuildMember(signupPlayer)) {
+      await interaction.reply(
+        "Team not signed up. Signup initiated by member that cannot be found. Contact admin",
+      );
+      return;
+    }
     await interaction.reply("Fetched all input, working on request");
 
     const overstatRequiredDeadline = new Date(1742799600000);

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -211,11 +211,10 @@ export abstract class DB {
     return returnedData.insert_players_one.id;
   }
 
-  /* returns list of id's
-   *
-   * Created a special method that inserts players if they do not exist, also takes special care not to overwrite overstats and elo if they are in DB but not included in player object
+  /*
+   * A special method that inserts players if they do not exist, also takes special care not to overwrite overstats and elo if they are in DB but not included in player object
    */
-  async insertPlayers(players: PlayerInsert[]): Promise<string[]> {
+  async insertPlayers(players: PlayerInsert[]): Promise<Player[]> {
     const playerMap: Map<string, PlayerInsert> = new Map();
     for (const player of players) {
       playerMap.set(player.discordId, player);
@@ -240,6 +239,8 @@ export abstract class DB {
         returning {
           id
           discord_id
+          overstat_id
+          display_name
         }
       }
     `;
@@ -251,18 +252,33 @@ export abstract class DB {
       }
     `;
     const result: JSONValue = await this.customQuery(query);
-    const returnedData: {
-      insert_players: { returning: { id: string; discord_id: string }[] };
-    } = result as {
-      insert_players: { returning: { id: string; discord_id: string }[] };
+    const returnedData = result as {
+      insert_players: {
+        returning: {
+          id: string;
+          discord_id: string;
+          overstat_id: string;
+          display_name: string;
+        }[];
+      };
     };
 
-    return players.map(
-      (player) =>
-        returnedData.insert_players.returning.find(
+    return players
+      .map((player) => {
+        const playerData = returnedData.insert_players.returning.find(
           (entry) => entry.discord_id === player.discordId,
-        )?.id as string,
-    );
+        );
+        if (!playerData) {
+          return undefined;
+        }
+        return {
+          id: playerData.id,
+          discordId: playerData.discord_id,
+          displayName: playerData.display_name,
+          overstatId: playerData.overstat_id,
+        };
+      })
+      .filter((player) => !!player);
   }
 
   // This feels like a really gross way to grab a single entry

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -19,5 +19,6 @@ export const signupsService = new ScrimSignups(
   cache,
   overstatService,
   prioService,
+  authService,
 );
 export const rosterService = new RosterService(nhostDb, cache, authService);

--- a/src/services/overstat.ts
+++ b/src/services/overstat.ts
@@ -30,10 +30,6 @@ export class OverstatService {
     return tournamentId;
   }
 
-  private getPlayerUrl(playerId: string) {
-    return `https://overstat.gg/player/${playerId}/overview`;
-  }
-
   // We may want to make sure that the ID returns a valid player
   // https://overstat.gg/api/player/{id} could be used for this
   private getPlayerId(overstatLink: string): string {
@@ -142,6 +138,10 @@ export class OverstatService {
     if (!player.overstatId) {
       throw Error("Player has no overstat id");
     }
-    return this.getPlayerUrl(player.overstatId);
+    return getPlayerOverstatUrl(player.overstatId);
   }
 }
+
+export const getPlayerOverstatUrl = (playerId: string) => {
+  return `https://overstat.gg/player/${playerId}/overview`;
+};

--- a/src/services/prio.ts
+++ b/src/services/prio.ts
@@ -106,9 +106,16 @@ export class PrioService {
           amount: player.amount,
           reason: player.reason,
         });
-      } else {
+        // if new entry is negative override all prio to be negative
+      } else if (player.amount < 0) {
         playerMap.set(player.discordId, {
-          amount: playerPrio.amount + player.amount,
+          amount: player.amount,
+          reason: playerPrio.reason + ", " + player.reason,
+        });
+        // if new entry is positive let previous (potentially negative) prio override new amount
+      } else if (player.amount >= 0) {
+        playerMap.set(player.discordId, {
+          amount: playerPrio.amount,
           reason: playerPrio.reason + ", " + player.reason,
         });
       }
@@ -122,9 +129,14 @@ export class PrioService {
           amount: 1,
           reason: "Scrim pass",
         });
+      } else if (playerPrio.amount < 0) {
+        playerMap.set(id, {
+          amount: -1,
+          reason: playerPrio.reason + ", " + "Scrim pass",
+        });
       } else if (playerPrio.amount > 0) {
         playerMap.set(id, {
-          amount: playerPrio.amount + 1,
+          amount: 1,
           reason: playerPrio.reason + ", " + "Scrim pass",
         });
       }

--- a/src/services/prio.ts
+++ b/src/services/prio.ts
@@ -65,15 +65,16 @@ export class PrioService {
     return { cacheMissedPlayers, playerIds };
   }
 
-  private fetchCacheMissedPlayerIds(
+  private async fetchCacheMissedPlayerIds(
     cacheMissedPlayers: User[],
   ): Promise<string[]> {
-    return this.db.insertPlayers(
+    const insertedPlayers = await this.db.insertPlayers(
       cacheMissedPlayers.map((player) => ({
         discordId: player.id,
         displayName: player.displayName,
       })),
     );
+    return insertedPlayers.map((player) => player.id);
   }
 
   private addPlayersToCache(players: User[], playerIds: string[]) {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -185,7 +185,7 @@ export class ScrimSignups {
     for (const player of players) {
       if (!player.overstatId) {
         throw Error(
-          `No overstat linked for ${player.displayName}. Don't have an overstat? Create a https://discord.com/channels/1043350338574495764/1335824833757450263 and let an admin know your signup information so they can complete it for you`,
+          `No overstat linked for ${player.displayName}. Use /link-overstat in https://discord.com/channels/1043350338574495764/1341877592139104376. Don't have an overstat? Create a https://discord.com/channels/1043350338574495764/1335824833757450263 and let an admin know your signup information so they can complete it for you`,
         );
       }
     }

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -141,7 +141,7 @@ export class ScrimSignups {
       }),
     );
     const insertedPlayers = await this.db.insertPlayers(convertedPlayers);
-    this.checkForMissingOverstat(insertedPlayers);
+    this.checkForMissingOverstat(insertedPlayers.slice(1));
     const signupDate = new Date();
     const signupId = await this.db.addScrimSignup(
       teamName,

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -141,7 +141,7 @@ export class ScrimSignups {
       }),
     );
     const insertedPlayers = await this.db.insertPlayers(convertedPlayers);
-    this.checkForMissingOverstat(insertedPlayers.slice(1));
+    this.checkForMissingOverstat(insertedPlayers.slice(1), scrim);
     const signupDate = new Date();
     const signupId = await this.db.addScrimSignup(
       teamName,
@@ -164,9 +164,9 @@ export class ScrimSignups {
     return scrimSignup;
   }
 
-  private checkForMissingOverstat(players: Player[]) {
+  private checkForMissingOverstat(players: Player[], scrim: Scrim) {
     const deadline = new Date(1742799600000);
-    if (new Date() < deadline) {
+    if (scrim.dateTime < deadline) {
       return;
     }
     for (const player of players) {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -102,7 +102,7 @@ export class ScrimSignups {
     teamName: string,
     commandUser: User,
     players: User[],
-  ): Promise<string> {
+  ): Promise<ScrimSignup> {
     const scrim = this.cache.getScrim(discordChannelID);
     if (!scrim) {
       throw Error("No scrim found for that channel");
@@ -152,15 +152,16 @@ export class ScrimSignups {
       insertedPlayers[3].id,
       signupDate,
     );
-    scrimSignups.push({
+    const scrimSignup: ScrimSignup = {
       teamName: teamName,
       players: insertedPlayers.slice(1),
       signupPlayer: insertedPlayers[0],
       signupId,
       date: signupDate,
-    });
+    };
+    scrimSignups.push(scrimSignup);
     this.cache.setSignups(scrim.id, scrimSignups);
-    return signupId;
+    return scrimSignup;
   }
 
   private checkForMissingOverstat(players: Player[]) {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -165,6 +165,10 @@ export class ScrimSignups {
   }
 
   private checkForMissingOverstat(players: Player[]) {
+    const deadline = new Date(1742799600000);
+    if (new Date() < deadline) {
+      return;
+    }
     for (const player of players) {
       if (!player.overstatId) {
         throw Error("No overstat linked for " + player.displayName);

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -1,4 +1,4 @@
-import { User } from "discord.js";
+import { GuildMember, User } from "discord.js";
 import { Player, PlayerInsert, PlayerStatInsert } from "../models/Player";
 import { DB } from "../db/db";
 import { ScrimSignupsWithPlayers } from "../db/table.interfaces";
@@ -7,6 +7,7 @@ import { OverstatService } from "./overstat";
 import { Scrim, ScrimSignup } from "../models/Scrims";
 import { PrioService } from "./prio";
 import { appConfig } from "../config";
+import { AuthService } from "./auth";
 
 export class ScrimSignups {
   constructor(
@@ -14,6 +15,7 @@ export class ScrimSignups {
     private cache: CacheService,
     private overstatService: OverstatService,
     private prioService: PrioService,
+    private authService: AuthService,
   ) {
     this.updateActiveScrims();
   }
@@ -100,7 +102,7 @@ export class ScrimSignups {
   async addTeam(
     discordChannelID: string,
     teamName: string,
-    commandUser: User,
+    commandUser: GuildMember,
     players: User[],
   ): Promise<ScrimSignup> {
     const scrim = this.cache.getScrim(discordChannelID);
@@ -135,13 +137,17 @@ export class ScrimSignups {
     }
     const playersToInsert = [commandUser, ...players];
     const convertedPlayers: PlayerInsert[] = playersToInsert.map(
-      (discordUser: User) => ({
+      (discordUser) => ({
         discordId: discordUser.id as string,
         displayName: discordUser.displayName,
       }),
     );
     const insertedPlayers = await this.db.insertPlayers(convertedPlayers);
-    this.checkForMissingOverstat(insertedPlayers.slice(1), scrim);
+    await this.checkForMissingOverstat(
+      insertedPlayers.slice(1),
+      scrim,
+      commandUser,
+    );
     const signupDate = new Date();
     const signupId = await this.db.addScrimSignup(
       teamName,
@@ -164,14 +170,23 @@ export class ScrimSignups {
     return scrimSignup;
   }
 
-  private checkForMissingOverstat(players: Player[], scrim: Scrim) {
+  private async checkForMissingOverstat(
+    players: Player[],
+    scrim: Scrim,
+    commandMember: GuildMember,
+  ) {
+    if (await this.authService.memberIsAdmin(commandMember)) {
+      return;
+    }
     const deadline = new Date(1742799600000);
     if (scrim.dateTime < deadline) {
       return;
     }
     for (const player of players) {
       if (!player.overstatId) {
-        throw Error("No overstat linked for " + player.displayName);
+        throw Error(
+          `No overstat linked for ${player.displayName}. Don't have an overstat? Create a https://discord.com/channels/1043350338574495764/1335824833757450263 and let an admin know your signup information so they can complete it for you`,
+        );
       }
     }
   }

--- a/test/commands/overstat/add-overstat-link.test.ts
+++ b/test/commands/overstat/add-overstat-link.test.ts
@@ -34,7 +34,7 @@ describe("Link overstat", () => {
   >;
 
   const mockAuthService = new AuthMock();
-  const mockOverstatService = new OverstatServiceMock(new DbMock());
+  const mockOverstatService = new OverstatServiceMock();
 
   let command: LinkOverstatCommand;
 

--- a/test/commands/overstat/get-overstat-link.test.ts
+++ b/test/commands/overstat/get-overstat-link.test.ts
@@ -11,7 +11,6 @@ import { AuthMock } from "../../mocks/auth.mock";
 import { OverstatService } from "../../../src/services/overstat";
 import { OverstatServiceMock } from "../../mocks/overstat.mock";
 import { AuthService } from "../../../src/services/auth";
-import { DbMock } from "../../mocks/db.mock";
 import { GetOverstatCommand } from "../../../src/commands/overstat/get-overstat";
 
 describe("Get overstat", () => {
@@ -25,7 +24,7 @@ describe("Get overstat", () => {
   >;
 
   const mockAuthService = new AuthMock();
-  const mockOverstatService = new OverstatServiceMock(new DbMock());
+  const mockOverstatService = new OverstatServiceMock();
 
   let command: GetOverstatCommand;
 

--- a/test/commands/signup/signup.test.ts
+++ b/test/commands/signup/signup.test.ts
@@ -109,7 +109,7 @@ describe("Sign up", () => {
     );
     expect(followUpSpy).toHaveBeenCalledWith({
       content:
-        "Player 1 is missing overstat id.\nPlayer 2 is missing overstat id.\nPlayer 3 is missing overstat id.\nScrims starting on <t:1742799600:f> will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376",
+        "Player 1 is missing overstat id.\nPlayer 2 is missing overstat id.\nPlayer 3 is missing overstat id.\nScrims starting after <t:1742799600:f> will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376",
       ephemeral: true,
     });
   });

--- a/test/commands/signup/signup.test.ts
+++ b/test/commands/signup/signup.test.ts
@@ -1,4 +1,5 @@
 import {
+  GuildMember,
   InteractionEditReplyOptions,
   InteractionReplyOptions,
   InteractionResponse,
@@ -38,12 +39,13 @@ describe("Sign up", () => {
 
   let command: SignupCommand;
 
-  const mockScrimSignups = new ScrimSignupMock();
-
-  const signupUser = {
+  const signupMember = {
     displayName: "Signup User",
     id: "signupPlayerId",
-  } as User;
+    roles: {},
+  } as GuildMember;
+
+  const mockScrimSignups = new ScrimSignupMock();
 
   const player1 = {
     displayName: "Player 1",
@@ -80,7 +82,7 @@ describe("Sign up", () => {
         },
         getString: () => "team name",
       },
-      user: signupUser,
+      member: signupMember,
     } as unknown as CustomInteraction;
     replySpy = jest.spyOn(basicInteraction, "reply");
     editReplySpy = jest.spyOn(basicInteraction, "editReply");
@@ -101,7 +103,7 @@ describe("Sign up", () => {
     expect(signupAddTeamSpy).toHaveBeenCalledWith(
       "forum thread id",
       "team name",
-      signupUser,
+      signupMember,
       signupPlayers,
     );
     expect(editReplySpy).toHaveBeenCalledWith(
@@ -151,7 +153,7 @@ describe("Sign up", () => {
     expect(signupAddTeamSpy).toHaveBeenCalledWith(
       "forum thread id",
       "team name",
-      signupUser,
+      signupMember,
       signupPlayers,
     );
     expect(editReplySpy).toHaveBeenCalledWith(
@@ -169,6 +171,22 @@ describe("Sign up", () => {
       await command.run(basicInteraction);
       expect(editReplySpy).toHaveBeenCalledWith(
         "Team not signed up. Error: DB Failure",
+      );
+    });
+
+    it("should not create scrim because the command member does not exist", async () => {
+      const errorInteraction = {
+        reply: jest.fn(),
+        options: {
+          getUser: jest.fn(),
+          getString: jest.fn(),
+        },
+        member: undefined,
+      } as unknown as CustomInteraction;
+      replySpy = jest.spyOn(errorInteraction, "reply");
+      await command.run(errorInteraction);
+      expect(replySpy).toHaveBeenCalledWith(
+        "Team not signed up. Signup initiated by member that cannot be found. Contact admin",
       );
     });
   });

--- a/test/commands/signup/signup.test.ts
+++ b/test/commands/signup/signup.test.ts
@@ -11,6 +11,7 @@ import { CustomInteraction } from "../../../src/commands/interaction";
 import { ScrimSignupMock } from "../../mocks/signups.mock";
 import { ScrimSignups } from "../../../src/services/signups";
 import { SignupCommand } from "../../../src/commands/signup/sign-up";
+import { ScrimSignup } from "../../../src/models/Scrims";
 
 describe("Sign up", () => {
   let basicInteraction: CustomInteraction;
@@ -24,8 +25,13 @@ describe("Sign up", () => {
     [options: string | InteractionEditReplyOptions | MessagePayload],
     string
   >;
+  let followUpSpy: SpyInstance<
+    Promise<Message<boolean>>,
+    [reply: string | InteractionReplyOptions | MessagePayload],
+    string
+  >;
   let signupAddTeamSpy: SpyInstance<
-    Promise<string>,
+    Promise<ScrimSignup>,
     [channelId: string, teamName: string, signupPlayer: User, players: User[]],
     string
   >;
@@ -61,6 +67,7 @@ describe("Sign up", () => {
       channelId: "forum thread id",
       reply: jest.fn(),
       editReply: jest.fn(),
+      followUp: jest.fn(),
       options: {
         getUser: (key: string) => {
           if (key === "player1") {
@@ -77,20 +84,19 @@ describe("Sign up", () => {
     } as unknown as CustomInteraction;
     replySpy = jest.spyOn(basicInteraction, "reply");
     editReplySpy = jest.spyOn(basicInteraction, "editReply");
+    followUpSpy = jest.spyOn(basicInteraction, "followUp");
     signupAddTeamSpy = jest.spyOn(mockScrimSignups, "addTeam");
-    signupAddTeamSpy.mockImplementation(() => {
-      return Promise.resolve("db id");
-    });
   });
 
   beforeEach(() => {
     replySpy.mockClear();
     editReplySpy.mockClear();
+    followUpSpy.mockClear();
     signupAddTeamSpy.mockClear();
     command = new SignupCommand(mockScrimSignups as unknown as ScrimSignups);
   });
 
-  it("Should complete signup", async () => {
+  it("Should complete signup but include warnings", async () => {
     await command.run(basicInteraction);
     expect(signupAddTeamSpy).toHaveBeenCalledWith(
       "forum thread id",
@@ -99,8 +105,59 @@ describe("Sign up", () => {
       signupPlayers,
     );
     expect(editReplySpy).toHaveBeenCalledWith(
-      `Team team name signed up with players: <@player1id>, <@player2id>, <@player3id>, signed up by <@signupPlayerId>. Signup id: db id`,
+      `team name\n<@player1id>, <@player2id>, <@player3id>\nSigned up by <@signupPlayerId>.\nscrim signup db id`,
     );
+    expect(followUpSpy).toHaveBeenCalledWith({
+      content:
+        "Player 1 is missing overstat id.\nPlayer 2 is missing overstat id.\nPlayer 3 is missing overstat id.\nScrims starting on <t:1742799:f> will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376",
+      ephemeral: true,
+    });
+  });
+
+  it("Should complete warnings", async () => {
+    signupAddTeamSpy.mockReturnValueOnce(
+      Promise.resolve({
+        signupId: "scrim signup db id",
+        players: [
+          {
+            discordId: player1.id,
+            id: "player db id 1",
+            displayName: player1.displayName,
+            overstatId: "1",
+          },
+          {
+            discordId: player2.id,
+            id: "player db id 2",
+            displayName: player2.displayName,
+            overstatId: "2",
+          },
+          {
+            discordId: player3.id,
+            id: "player db id 3",
+            displayName: player3.displayName,
+            overstatId: "3",
+          },
+        ],
+        signupPlayer: {
+          discordId: player1.id,
+          displayName: player1.displayName,
+          id: "player db id 1",
+        },
+        teamName: "team name",
+        date: new Date(),
+      }),
+    );
+    await command.run(basicInteraction);
+    expect(signupAddTeamSpy).toHaveBeenCalledWith(
+      "forum thread id",
+      "team name",
+      signupUser,
+      signupPlayers,
+    );
+    expect(editReplySpy).toHaveBeenCalledWith(
+      `team name\n<@player1id>, <@player2id>, <@player3id>\nSigned up by <@signupPlayerId>.\nscrim signup db id`,
+    );
+    expect(followUpSpy).toHaveBeenCalledTimes(0);
   });
 
   describe("errors", () => {

--- a/test/commands/signup/signup.test.ts
+++ b/test/commands/signup/signup.test.ts
@@ -109,7 +109,7 @@ describe("Sign up", () => {
     );
     expect(followUpSpy).toHaveBeenCalledWith({
       content:
-        "Player 1 is missing overstat id.\nPlayer 2 is missing overstat id.\nPlayer 3 is missing overstat id.\nScrims starting on <t:1742799:f> will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376",
+        "Player 1 is missing overstat id.\nPlayer 2 is missing overstat id.\nPlayer 3 is missing overstat id.\nScrims starting on <t:1742799600:f> will reject signups that include players without overstat id. Use the /link-overstat command in https://discord.com/channels/1043350338574495764/1341877592139104376",
       ephemeral: true,
     });
   });

--- a/test/db.test.ts
+++ b/test/db.test.ts
@@ -588,6 +588,8 @@ describe("DB connection", () => {
               returning {
                 id
                 discord_id
+                overstat_id
+                display_name
               }
            }
 
@@ -662,7 +664,7 @@ describe("DB connection", () => {
         supreme,
         theheuman,
       ]);
-      expect(newID).toEqual([
+      expect(newID.map((player) => player.id)).toEqual([
         "11583f2c-184f-4ab5-9f6f-ff33f2741117",
         "11583f2c-184f-4ab5-9f6f-ff33f2741117",
         "7605b2bf-1875-4415-a04b-75fe47768565",

--- a/test/mocks/db.mock.ts
+++ b/test/mocks/db.mock.ts
@@ -1,6 +1,6 @@
 import { DB } from "../../src/db/db";
 import { DbValue, JSONValue, LogicalExpression } from "../../src/db/types";
-import { PlayerInsert } from "../../src/models/Player";
+import { Player, PlayerInsert } from "../../src/models/Player";
 import { ScrimSignupsWithPlayers } from "../../src/db/table.interfaces";
 
 export class DbMock extends DB {
@@ -9,7 +9,7 @@ export class DbMock extends DB {
   getResponse: JSONValue;
   postResponse: string[];
   addScrimSignupResponse: string;
-  insertPlayersResponse: string[];
+  insertPlayersResponse: Player[];
   insertPlayerIfNotExistsResponse: string;
 
   constructor() {
@@ -20,7 +20,7 @@ export class DbMock extends DB {
     this.getResponse = {};
     this.postResponse = [""];
     this.addScrimSignupResponse = "";
-    this.insertPlayersResponse = [""];
+    this.insertPlayersResponse = [];
     this.insertPlayerIfNotExistsResponse = "";
   }
 
@@ -67,7 +67,7 @@ export class DbMock extends DB {
     return Promise.resolve(this.insertPlayerIfNotExistsResponse);
   }
 
-  async insertPlayers(players: PlayerInsert[]): Promise<string[]> {
+  async insertPlayers(players: PlayerInsert[]): Promise<Player[]> {
     return Promise.resolve(this.insertPlayersResponse);
   }
 

--- a/test/mocks/overstat.mock.ts
+++ b/test/mocks/overstat.mock.ts
@@ -5,7 +5,7 @@ import { ScrimSignup } from "../../src/models/Scrims";
 import { PlayerStatInsert } from "../../src/models/Player";
 
 export class OverstatServiceMock {
-  constructor(private db: DB) {}
+  constructor() {}
 
   async getOverallStats(
     overstatLink: string,

--- a/test/mocks/signups.mock.ts
+++ b/test/mocks/signups.mock.ts
@@ -36,7 +36,7 @@ export class ScrimSignupMock {
     teamName: string,
     commandUser: User,
     players: User[],
-  ): Promise<string> {
+  ): Promise<ScrimSignup> {
     console.log(
       "Adding team in signup mock",
       channelId,
@@ -44,7 +44,21 @@ export class ScrimSignupMock {
       commandUser,
       players,
     );
-    return "";
+    return {
+      date: new Date(),
+      players: players.map((player, index) => ({
+        displayName: player.displayName,
+        discordId: player.id,
+        id: "db player id " + index,
+      })),
+      signupId: "scrim signup db id",
+      signupPlayer: {
+        displayName: commandUser.displayName,
+        discordId: commandUser.id,
+        id: "db player id",
+      },
+      teamName: teamName,
+    };
   }
 
   async getSignups(

--- a/test/services/prio.test.ts
+++ b/test/services/prio.test.ts
@@ -191,6 +191,18 @@ describe("Prio", () => {
               reason: "bad boi",
             },
             {
+              id: lowPrioPlayerOnTeam.id,
+              discordId: lowPrioPlayerOnTeam.discordId,
+              amount: 1,
+              reason: "Scrim got messed up",
+            },
+            {
+              id: lowPrioPlayerOnTeam.id,
+              discordId: lowPrioPlayerOnTeam.discordId,
+              amount: -1,
+              reason: "bad boi",
+            },
+            {
               id: highPrioPlayerOnTeam.id,
               discordId: highPrioPlayerOnTeam.discordId,
               amount: 1,
@@ -199,6 +211,12 @@ describe("Prio", () => {
             {
               id: highPrioPlayerOnTeam.id,
               discordId: highPrioPlayerOnTeam.discordId,
+              amount: 1,
+              reason: "good boi",
+            },
+            {
+              id: scrimPassHolder.id,
+              discordId: scrimPassHolder.discordId,
               amount: 1,
               reason: "good boi",
             },
@@ -238,11 +256,12 @@ describe("Prio", () => {
             prio: {
               amount: -1,
               reasons:
-                "Bad Boi: bad boi; Good Boi: good boi, good boi; Rich boi: Scrim pass",
+                "Bad Boi: bad boi, Scrim got messed up, bad boi, Scrim pass; Good Boi: good boi, good boi; Rich boi: good boi, Scrim pass",
             },
           },
         ]);
       });
+
       it("should set high prio for teams from its players", async () => {
         const today = new Date();
         const scrim: Scrim = {

--- a/test/services/prio.test.ts
+++ b/test/services/prio.test.ts
@@ -1,9 +1,8 @@
-import { GuildMember, User } from "discord.js";
+import { User } from "discord.js";
 import { Player, PlayerInsert } from "../../src/models/Player";
 import { PrioService } from "../../src/services/prio";
 import { DbMock } from "../mocks/db.mock";
 import { CacheService } from "../../src/services/cache";
-import { AuthService } from "../../src/services/auth";
 import SpyInstance = jest.SpyInstance;
 import { Scrim, ScrimSignup } from "../../src/models/Scrims";
 
@@ -48,7 +47,7 @@ describe("Prio", () => {
 
     describe("correctly set prio", () => {
       let insertSpy: SpyInstance<
-        Promise<string[]>,
+        Promise<Player[]>,
         [players: PlayerInsert[]],
         string
       >;
@@ -69,7 +68,15 @@ describe("Prio", () => {
         dbSetPrioSpy = jest.spyOn(dbMock, "setPrio");
         insertSpy.mockClear();
         dbSetPrioSpy.mockClear();
-        insertSpy.mockReturnValue(Promise.resolve(["a different db id"]));
+        insertSpy.mockReturnValue(
+          Promise.resolve([
+            {
+              id: "a different db id",
+              discordId: "discord id",
+              displayName: "test user",
+            },
+          ]),
+        );
       });
 
       it("should set prio for players in cache", async () => {

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -258,13 +258,16 @@ describe("Signups", () => {
     });
 
     describe("Missing overstat id", () => {
-      beforeEach(() => {
+      const createScrim = (dateTime: Date) => {
         cache.createScrim("1", {
           id: "2",
           discordChannel: "1",
           active: true,
+          dateTime,
         } as Scrim);
+      };
 
+      beforeEach(() => {
         insertPlayersSpy.mockReturnValueOnce(
           Promise.resolve([
             {
@@ -292,16 +295,10 @@ describe("Signups", () => {
             },
           ]),
         );
-
-        jest.useFakeTimers();
-      });
-
-      afterEach(() => {
-        jest.useRealTimers();
       });
 
       it("Should add a team because overstat required deadline not reached", async () => {
-        jest.setSystemTime(new Date(174279960000));
+        createScrim(new Date(174279960000));
 
         const actualSignup = await signups.addTeam(
           "1",
@@ -314,7 +311,7 @@ describe("Signups", () => {
       });
 
       it("Should not add a team because a player doesn't have an overstat id", async () => {
-        jest.setSystemTime(new Date(17427996000000));
+        createScrim(new Date(17427996000000));
 
         const causeException = async () => {
           await signups.addTeam("1", "Dude Cube", theheuman, [

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -33,7 +33,6 @@ describe("Signups", () => {
           id: "111",
           discordId: "123",
           displayName: "TheHeuman",
-          overstatId: "123",
         },
         {
           id: "111",
@@ -223,6 +222,54 @@ describe("Signups", () => {
       };
 
       await expect(causeException).rejects.toThrow("");
+    });
+
+    it("Should not add a team because a player doesn't have an overstat id", async () => {
+      cache.createScrim("1", {
+        id: "2",
+        discordChannel: "1",
+        active: true,
+      } as Scrim);
+
+      const causeException = async () => {
+        await signups.addTeam("1", "Dude Cube", theheuman, [
+          theheuman,
+          supreme,
+          mikey,
+        ]);
+      };
+
+      insertPlayersSpy.mockReturnValueOnce(
+        Promise.resolve([
+          {
+            id: "111",
+            discordId: "123",
+            displayName: "TheHeuman",
+            overstatId: "123",
+          },
+          {
+            id: "111",
+            discordId: "123",
+            displayName: "TheHeuman",
+          },
+          {
+            id: "444",
+            discordId: "456",
+            displayName: "Zboy",
+            overstatId: "456",
+          },
+          {
+            id: "777",
+            discordId: "789",
+            displayName: "Supreme",
+            overstatId: "789",
+          },
+        ]),
+      );
+
+      await expect(causeException).rejects.toThrow(
+        "No overstat linked for TheHeuman",
+      );
     });
   });
 

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -60,6 +60,9 @@ describe("Signups", () => {
 
   describe("addTeam()", () => {
     it("Should add a team", async () => {
+      jest.useFakeTimers();
+      const now = new Date();
+      jest.setSystemTime(now);
       const expectedSignup = {
         teamName: "Fineapples",
         scrimId: "32451",
@@ -93,13 +96,43 @@ describe("Signups", () => {
           },
         );
 
-      const signupId = await signups.addTeam(
+      const actualScrimSignup = await signups.addTeam(
         expectedSignup.discordChannelId,
         expectedSignup.teamName,
         theheuman,
         [theheuman, zboy, supreme],
       );
-      expect(signupId).toEqual(expectedSignup.signupId);
+      const expectedReturnSignup: ScrimSignup = {
+        date: now,
+        teamName: expectedSignup.teamName,
+        signupId: expectedSignup.signupId,
+        players: [
+          {
+            id: "111",
+            discordId: theheuman.id,
+            displayName: theheuman.displayName,
+            overstatId: theheuman.id,
+          },
+          {
+            id: "444",
+            discordId: zboy.id,
+            displayName: zboy.displayName,
+            overstatId: zboy.id,
+          },
+          {
+            id: "777",
+            discordId: supreme.id,
+            displayName: supreme.displayName,
+            overstatId: supreme.id,
+          },
+        ],
+        signupPlayer: {
+          id: "111",
+          discordId: theheuman.id,
+          displayName: theheuman.displayName,
+        },
+      };
+      expect(actualScrimSignup).toEqual(expectedReturnSignup);
       expect(insertPlayersSpy).toHaveBeenCalledWith([
         { discordId: "123", displayName: "TheHeuman" },
         { discordId: "123", displayName: "TheHeuman" },

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -257,52 +257,77 @@ describe("Signups", () => {
       await expect(causeException).rejects.toThrow("");
     });
 
-    it("Should not add a team because a player doesn't have an overstat id", async () => {
-      cache.createScrim("1", {
-        id: "2",
-        discordChannel: "1",
-        active: true,
-      } as Scrim);
+    describe("Missing overstat id", () => {
+      beforeEach(() => {
+        cache.createScrim("1", {
+          id: "2",
+          discordChannel: "1",
+          active: true,
+        } as Scrim);
 
-      const causeException = async () => {
-        await signups.addTeam("1", "Dude Cube", theheuman, [
+        insertPlayersSpy.mockReturnValueOnce(
+          Promise.resolve([
+            {
+              id: "111",
+              discordId: "123",
+              displayName: "TheHeuman",
+              overstatId: "123",
+            },
+            {
+              id: "111",
+              discordId: "123",
+              displayName: "TheHeuman",
+            },
+            {
+              id: "444",
+              discordId: "456",
+              displayName: "Zboy",
+              overstatId: "456",
+            },
+            {
+              id: "777",
+              discordId: "789",
+              displayName: "Supreme",
+              overstatId: "789",
+            },
+          ]),
+        );
+
+        jest.useFakeTimers();
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it("Should add a team because overstat required deadline not reached", async () => {
+        jest.setSystemTime(new Date(174279960000));
+
+        const actualSignup = await signups.addTeam(
+          "1",
+          "Dude Cube",
           theheuman,
-          supreme,
-          mikey,
-        ]);
-      };
+          [theheuman, supreme, mikey],
+        );
 
-      insertPlayersSpy.mockReturnValueOnce(
-        Promise.resolve([
-          {
-            id: "111",
-            discordId: "123",
-            displayName: "TheHeuman",
-            overstatId: "123",
-          },
-          {
-            id: "111",
-            discordId: "123",
-            displayName: "TheHeuman",
-          },
-          {
-            id: "444",
-            discordId: "456",
-            displayName: "Zboy",
-            overstatId: "456",
-          },
-          {
-            id: "777",
-            discordId: "789",
-            displayName: "Supreme",
-            overstatId: "789",
-          },
-        ]),
-      );
+        expect(actualSignup).toBeDefined();
+      });
 
-      await expect(causeException).rejects.toThrow(
-        "No overstat linked for TheHeuman",
-      );
+      it("Should not add a team because a player doesn't have an overstat id", async () => {
+        jest.setSystemTime(new Date(17427996000000));
+
+        const causeException = async () => {
+          await signups.addTeam("1", "Dude Cube", theheuman, [
+            theheuman,
+            supreme,
+            mikey,
+          ]);
+        };
+
+        await expect(causeException).rejects.toThrow(
+          "No overstat linked for TheHeuman",
+        );
+      });
     });
   });
 


### PR DESCRIPTION
* Require overstats for scrims starting after a deadline of march 24
* Until deadline warn on signup that players are missing overstats
* Player prio no longer stacks
* Overstat returned in get signups csv