### PR TITLE
feature/scrim-signup-count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrim-bot",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrim-bot",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@nhost/nhost-js": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrim-bot",
   "description": "A multipurpose bot to track scrim signups, low prio and player performance among other things",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Jacob Heuman",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -1,0 +1,10 @@
+import { GatewayIntentBits } from "discord.js";
+import { ExtendedClient } from "./ExtendedClient";
+
+export const client = new ExtendedClient({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildPresences,
+    GatewayIntentBits.GuildMembers,
+  ],
+});

--- a/src/ExtendedClient.ts
+++ b/src/ExtendedClient.ts
@@ -1,4 +1,9 @@
-import { Client, ClientOptions, Collection } from "discord.js";
+import {
+  Client,
+  ClientOptions,
+  Collection,
+  GatewayIntentBits,
+} from "discord.js";
 import { Command } from "./commands/command";
 
 class ExtendedClient extends Client {
@@ -10,4 +15,10 @@ class ExtendedClient extends Client {
   }
 }
 
-export default ExtendedClient;
+export const client = new ExtendedClient({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildPresences,
+    GatewayIntentBits.GuildMembers,
+  ],
+});

--- a/src/ExtendedClient.ts
+++ b/src/ExtendedClient.ts
@@ -1,12 +1,7 @@
-import {
-  Client,
-  ClientOptions,
-  Collection,
-  GatewayIntentBits,
-} from "discord.js";
+import { Client, ClientOptions, Collection } from "discord.js";
 import { Command } from "./commands/command";
 
-class ExtendedClient extends Client {
+export class ExtendedClient extends Client {
   commands: Collection<string, Command>;
 
   constructor(options: ClientOptions) {
@@ -14,11 +9,3 @@ class ExtendedClient extends Client {
     this.commands = new Collection();
   }
 }
-
-export const client = new ExtendedClient({
-  intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildPresences,
-    GatewayIntentBits.GuildMembers,
-  ],
-});

--- a/src/commands/admin/scrim-crud/create-scrim.ts
+++ b/src/commands/admin/scrim-crud/create-scrim.ts
@@ -8,6 +8,7 @@ import { StaticValueService } from "../../../services/static-values";
 import { ForumThreadChannel } from "discord.js/typings";
 import { ChannelType } from "discord-api-types/v10";
 import {
+  getScrimInfoTimes,
   isForumChannel,
   replaceScrimVariables,
 } from "../../../utility/utility";
@@ -123,27 +124,16 @@ export class CreateScrimCommand extends AdminCommand {
     if (!instructionText) {
       throw Error("Can't get instruction text from db");
     }
-    const lobbyPostDate = new Date(scrimDate.valueOf());
-    // 2 hours before
-    lobbyPostDate.setTime(lobbyPostDate.valueOf() - 2 * 60 * 60 * 1000);
-    const lobbyPostTime = this.formatTime(lobbyPostDate);
 
-    const lowPrioDate = new Date(scrimDate.valueOf());
-    // 1.5 hours before
-    lowPrioDate.setTime(lowPrioDate.valueOf() - 1.5 * 60 * 60 * 1000);
-    const lowPrioTime = this.formatTime(lowPrioDate);
-
-    const draftDate = new Date(scrimDate.valueOf());
-    // 20 minutes before
-    draftDate.setTime(draftDate.valueOf() - 20 * 60 * 1000);
-    const draftTime = this.formatTime(draftDate);
+    const { lobbyPostDate, lowPrioDate, draftDate } =
+      getScrimInfoTimes(scrimDate);
 
     return replaceScrimVariables(instructionText, {
       scrimTime: this.formatTime(scrimDate),
       scrimDate: this.formatDate(scrimDate),
-      lobbyPostTime,
-      lowPrioTime,
-      draftTime,
+      lobbyPostTime: this.formatTime(lobbyPostDate),
+      lowPrioTime: this.formatTime(lowPrioDate),
+      draftTime: this.formatTime(draftDate),
       signupCount: "0",
     });
   }

--- a/src/commands/admin/scrim-crud/create-scrim.ts
+++ b/src/commands/admin/scrim-crud/create-scrim.ts
@@ -7,7 +7,10 @@ import { AuthService } from "../../../services/auth";
 import { StaticValueService } from "../../../services/static-values";
 import { ForumThreadChannel } from "discord.js/typings";
 import { ChannelType } from "discord-api-types/v10";
-import { isForumChannel } from "../../../utility/utility";
+import {
+  isForumChannel,
+  replaceScrimVariables,
+} from "../../../utility/utility";
 
 export class CreateScrimCommand extends AdminCommand {
   inputNames = {
@@ -135,11 +138,13 @@ export class CreateScrimCommand extends AdminCommand {
     draftDate.setTime(draftDate.valueOf() - 20 * 60 * 1000);
     const draftTime = this.formatTime(draftDate);
 
-    return instructionText
-      .replace("${scrimTime}", this.formatTime(scrimDate))
-      .replace("${draftTime}", draftTime)
-      .replace("${lobbyPostTime}", lobbyPostTime)
-      .replace("${lowPrioTime}", lowPrioTime)
-      .replace(/\\n/g, "\n");
+    return replaceScrimVariables(instructionText, {
+      scrimTime: this.formatTime(scrimDate),
+      scrimDate: this.formatDate(scrimDate),
+      lobbyPostTime,
+      lowPrioTime,
+      draftTime,
+      signupCount: "0",
+    });
   }
 }

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -8,6 +8,7 @@ import { AuthService } from "../services/auth";
 import { ApplicationCommandOptionAllowedChannelTypes } from "@discordjs/builders";
 import { ScrimSignup } from "../models/Scrims";
 import { Player } from "../models/Player";
+import { formatDateForDiscord, formatTimeForDiscord } from "../utility/time";
 
 export abstract class Command extends SlashCommandBuilder {
   private loggableArguments: {
@@ -131,15 +132,15 @@ export abstract class Command extends SlashCommandBuilder {
       .setRequired(isRequired) as T;
   }
 
-  formatDate(date: Date) {
-    return `<t:${Math.floor(date.valueOf() / 1000)}:f>`;
+  formatDate(date: Date): string {
+    return formatDateForDiscord(date);
   }
 
-  formatTime(date: Date) {
-    return `<t:${Math.floor(date.valueOf() / 1000)}:t>`;
+  formatTime(date: Date): string {
+    return formatTimeForDiscord(date);
   }
 
-  formatTeam(team: ScrimSignup) {
+  formatTeam(team: ScrimSignup): string {
     const playerString = team.players
       .map((player) => this.formatPlayer(player))
       .join(" ");
@@ -151,7 +152,7 @@ export abstract class Command extends SlashCommandBuilder {
     return teamString + prioString;
   }
 
-  formatPlayer(player: Player) {
+  formatPlayer(player: Player): string {
     return `<@${player.discordId}>`;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,8 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { GatewayIntentBits } from "discord.js";
-import ExtendedClient from "./ExtendedClient";
+import { client } from "./ExtendedClient";
 import { commands } from "./commands";
 import { appConfig } from "./config";
-
-export const client = new ExtendedClient({
-  intents: [
-    GatewayIntentBits.Guilds,
-    GatewayIntentBits.GuildPresences,
-    GatewayIntentBits.GuildMembers,
-  ],
-});
 
 for (const command of commands) {
   client.commands.set(command.name, command);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { client } from "./ExtendedClient";
+import { client } from "./Client";
 import { commands } from "./commands";
 import { appConfig } from "./config";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { Events, GatewayIntentBits } from "discord.js";
+import { GatewayIntentBits } from "discord.js";
 import ExtendedClient from "./ExtendedClient";
 import { commands } from "./commands";
 import { appConfig } from "./config";
 
-const client = new ExtendedClient({
+export const client = new ExtendedClient({
   intents: [
     GatewayIntentBits.Guilds,
     GatewayIntentBits.GuildPresences,

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -3,6 +3,7 @@ import { appConfig } from "../config";
 import { StaticValueService } from "./static-values";
 import { Scrim } from "../models/Scrims";
 import { replaceScrimVariablesFromScrim } from "../utility/utility";
+import { ForumThreadChannel } from "discord.js/typings";
 
 export class DiscordService {
   constructor(
@@ -25,17 +26,18 @@ export class DiscordService {
       throw Error("Guild not found");
     }
 
-    const forumThread = guild.channels.cache.get(scrim.discordChannel);
+    const forumThread = guild.channels.cache.get(
+      scrim.discordChannel,
+    ) as ForumThreadChannel;
     if (!forumThread || forumThread.isThread() === false) {
       throw Error("Forum thread not found or not a valid thread");
     }
+    const description = await forumThread.fetchStarterMessage();
 
-    const messages = await forumThread.messages.fetch({ limit: 1 }); // Fetch the first message
-    const firstMessage = messages.first();
-
-    if (!firstMessage) {
+    if (!description) {
       throw Error("No messages found in the thread");
     }
-    firstMessage.edit(updatedMessage);
+
+    await description.edit(updatedMessage);
   }
 }

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -35,7 +35,7 @@ export class DiscordService {
     const description = await forumThread.fetchStarterMessage();
 
     if (!description) {
-      throw Error("No messages found in the thread");
+      throw Error("Signup post description not found");
     }
 
     await description.edit(updatedMessage);

--- a/src/services/discord.ts
+++ b/src/services/discord.ts
@@ -1,0 +1,41 @@
+import { Client } from "discord.js";
+import { appConfig } from "../config";
+import { StaticValueService } from "./static-values";
+import { Scrim } from "../models/Scrims";
+import { replaceScrimVariablesFromScrim } from "../utility/utility";
+
+export class DiscordService {
+  constructor(
+    private client: Client,
+    private staticValueService: StaticValueService,
+  ) {}
+
+  async updateSignupPostDescription(scrim: Scrim, signupCount: number) {
+    const instructionText = await this.staticValueService.getInstructionText();
+    if (!instructionText) {
+      throw Error("Instruction text not found");
+    }
+    const updatedMessage = replaceScrimVariablesFromScrim(
+      instructionText,
+      scrim,
+      signupCount,
+    );
+    const guild = this.client.guilds.cache.get(appConfig.discord.guildId);
+    if (!guild) {
+      throw Error("Guild not found");
+    }
+
+    const forumThread = guild.channels.cache.get(scrim.discordChannel);
+    if (!forumThread || forumThread.isThread() === false) {
+      throw Error("Forum thread not found or not a valid thread");
+    }
+
+    const messages = await forumThread.messages.fetch({ limit: 1 }); // Fetch the first message
+    const firstMessage = messages.first();
+
+    if (!firstMessage) {
+      throw Error("No messages found in the thread");
+    }
+    firstMessage.edit(updatedMessage);
+  }
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,7 +7,7 @@ import { PrioService } from "./prio";
 import { AuthService } from "./auth";
 import { StaticValueService } from "./static-values";
 import { DiscordService } from "./discord";
-import { client } from "../ExtendedClient";
+import { client } from "../Client";
 
 // This file creates all the singleton services
 export const cache = new CacheService();

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -6,11 +6,15 @@ import { OverstatService } from "./overstat";
 import { PrioService } from "./prio";
 import { AuthService } from "./auth";
 import { StaticValueService } from "./static-values";
+import { DiscordService } from "./discord";
+import { client } from "../index";
 
 // This file creates all the singleton services
 export const cache = new CacheService();
 export const overstatService = new OverstatService(nhostDb);
 export const staticValueService = new StaticValueService(nhostDb);
+
+export const discordService = new DiscordService(client, staticValueService);
 
 export const authService = new AuthService(nhostDb, cache);
 export const prioService = new PrioService(nhostDb, cache);
@@ -20,5 +24,11 @@ export const signupsService = new ScrimSignups(
   overstatService,
   prioService,
   authService,
+  discordService,
 );
-export const rosterService = new RosterService(nhostDb, cache, authService);
+export const rosterService = new RosterService(
+  nhostDb,
+  cache,
+  authService,
+  discordService,
+);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -7,7 +7,7 @@ import { PrioService } from "./prio";
 import { AuthService } from "./auth";
 import { StaticValueService } from "./static-values";
 import { DiscordService } from "./discord";
-import { client } from "../index";
+import { client } from "../ExtendedClient";
 
 // This file creates all the singleton services
 export const cache = new CacheService();

--- a/src/services/rosters.ts
+++ b/src/services/rosters.ts
@@ -75,7 +75,7 @@ export class RosterService {
       );
     await this.db.removeScrimSignup(teamToBeChanged.teamName, scrimId);
     signups.splice(signups.indexOf(teamToBeChanged), 1);
-    this.updateScrimSignupCount(scrimId);
+    this.updateScrimSignupCount(discordChannel);
   }
 
   async changeTeamName(

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -8,6 +8,7 @@ import { Scrim, ScrimSignup } from "../models/Scrims";
 import { PrioService } from "./prio";
 import { appConfig } from "../config";
 import { AuthService } from "./auth";
+import { DiscordService } from "./discord";
 
 export class ScrimSignups {
   constructor(
@@ -16,6 +17,7 @@ export class ScrimSignups {
     private overstatService: OverstatService,
     private prioService: PrioService,
     private authService: AuthService,
+    private discordService: DiscordService,
   ) {
     this.updateActiveScrims();
   }
@@ -167,6 +169,7 @@ export class ScrimSignups {
     };
     scrimSignups.push(scrimSignup);
     this.cache.setSignups(scrim.id, scrimSignups);
+    this.updateScrimSignupCount(scrim);
     return scrimSignup;
   }
 
@@ -286,5 +289,19 @@ export class ScrimSignups {
         },
       ],
     };
+  }
+
+  private async updateScrimSignupCount(scrim: Scrim) {
+    const count = this.cache.getSignups(scrim.id)?.length ?? 0;
+    try {
+      await this.discordService.updateSignupPostDescription(scrim, count);
+    } catch (e) {
+      console.error(
+        "Unable to update scrim signup count for ",
+        scrim.id,
+        scrim.discordChannel,
+        e,
+      );
+    }
   }
 }

--- a/src/utility/time.ts
+++ b/src/utility/time.ts
@@ -113,3 +113,11 @@ const getUtcOffset = (date: Date) => {
     getTimezoneOffset("America/New_York", date) / 60 / 60 / 1000;
   return `-${String(Math.abs(offsetHours)).padStart(2, "0")}:00`;
 };
+
+export const formatDateForDiscord = (date: Date): string => {
+  return `<t:${Math.floor(date.valueOf() / 1000)}:f>`;
+};
+
+export const formatTimeForDiscord = (date: Date): string => {
+  return `<t:${Math.floor(date.valueOf() / 1000)}:t>`;
+};

--- a/src/utility/utility.ts
+++ b/src/utility/utility.ts
@@ -1,6 +1,8 @@
 import { Channel, ForumChannel, GuildMember } from "discord.js";
 import type { APIInteractionGuildMember } from "../../node_modules/discord-api-types/payloads/v10/_interactions/base.d.ts";
 import { ChannelType } from "discord-api-types/v10";
+import { Scrim } from "../models/Scrims";
+import { formatDateForDiscord, formatTimeForDiscord } from "./time";
 
 export function isGuildMember(
   value: GuildMember | APIInteractionGuildMember | null,
@@ -10,6 +12,26 @@ export function isGuildMember(
 
 export function isForumChannel(value: Channel): value is ForumChannel {
   return (value as ForumChannel)?.type === ChannelType.GuildForum;
+}
+
+export function getScrimInfoTimes(scrimDate: Date): {
+  lobbyPostDate: Date;
+  lowPrioDate: Date;
+  draftDate: Date;
+} {
+  const lobbyPostDate = new Date(scrimDate.valueOf());
+  // 2 hours before
+  lobbyPostDate.setTime(lobbyPostDate.valueOf() - 2 * 60 * 60 * 1000);
+
+  const lowPrioDate = new Date(scrimDate.valueOf());
+  // 1.5 hours before
+  lowPrioDate.setTime(lowPrioDate.valueOf() - 1.5 * 60 * 60 * 1000);
+
+  const draftDate = new Date(scrimDate.valueOf());
+  // 20 minutes before
+  draftDate.setTime(draftDate.valueOf() - 20 * 60 * 1000);
+
+  return { lobbyPostDate, lowPrioDate, draftDate };
 }
 
 export function replaceScrimVariables(
@@ -31,4 +53,23 @@ export function replaceScrimVariables(
     .replace("${lowPrioTime}", replacements.lowPrioTime)
     .replace("${signupCount}", replacements.signupCount)
     .replace(/\\n/g, "\n");
+}
+
+export function replaceScrimVariablesFromScrim(
+  text: string,
+  scrim: Scrim,
+  signupCount: number,
+) {
+  const { draftDate, lobbyPostDate, lowPrioDate } = getScrimInfoTimes(
+    scrim.dateTime,
+  );
+
+  return replaceScrimVariables(text, {
+    scrimTime: formatTimeForDiscord(scrim.dateTime),
+    scrimDate: formatDateForDiscord(scrim.dateTime),
+    draftTime: formatTimeForDiscord(draftDate),
+    lobbyPostTime: formatTimeForDiscord(lobbyPostDate),
+    lowPrioTime: formatTimeForDiscord(lowPrioDate),
+    signupCount: signupCount.toString(),
+  });
 }

--- a/src/utility/utility.ts
+++ b/src/utility/utility.ts
@@ -11,3 +11,24 @@ export function isGuildMember(
 export function isForumChannel(value: Channel): value is ForumChannel {
   return (value as ForumChannel)?.type === ChannelType.GuildForum;
 }
+
+export function replaceScrimVariables(
+  text: string,
+  replacements: {
+    scrimTime: string;
+    scrimDate: string;
+    draftTime: string;
+    lobbyPostTime: string;
+    lowPrioTime: string;
+    signupCount: string;
+  },
+) {
+  return text
+    .replace("${scrimTime}", replacements.scrimTime)
+    .replace("${scrimDate}", replacements.scrimDate)
+    .replace("${draftTime}", replacements.draftTime)
+    .replace("${lobbyPostTime}", replacements.lobbyPostTime)
+    .replace("${lowPrioTime}", replacements.lowPrioTime)
+    .replace("${signupCount}", replacements.signupCount)
+    .replace(/\\n/g, "\n");
+}

--- a/test/mocks/discord-service.mock.ts
+++ b/test/mocks/discord-service.mock.ts
@@ -1,0 +1,10 @@
+import { Scrim } from "../../src/models/Scrims";
+
+export class DiscordServiceMock {
+  constructor() {}
+
+  async updateSignupPostDescription(scrim: Scrim, signupCount: number) {
+    console.log("Mock updateSignupPostDescription called", scrim, signupCount);
+    return Promise.resolve();
+  }
+}

--- a/test/services/discord-service.test.ts
+++ b/test/services/discord-service.test.ts
@@ -1,0 +1,147 @@
+import {
+  Guild,
+  Message,
+  MessageEditOptions,
+  MessagePayload,
+  OmitPartialGroupDMChannel,
+} from "discord.js";
+import { Scrim } from "../../src/models/Scrims";
+import { DiscordService } from "../../src/services/discord";
+import { StaticValueServiceMock } from "../mocks/static-values.mock";
+import { ExtendedClient } from "../../src/ExtendedClient";
+import { ForumThreadChannel } from "discord.js/typings";
+import { StaticValueService } from "../../src/services/static-values";
+import SpyInstance = jest.SpyInstance;
+
+jest.mock("../../src/config", () => {
+  return {
+    appConfig: {
+      discord: {
+        guildId: "a valid guild id",
+      },
+    },
+  };
+});
+
+describe("Discord service", () => {
+  let discordService: DiscordService;
+  let staticValueMock: StaticValueServiceMock;
+  let client: ExtendedClient;
+  let guild: Guild;
+  let forumChannel: ForumThreadChannel;
+  let message: Message;
+  let messageEditSpy: SpyInstance<
+    Promise<OmitPartialGroupDMChannel<Message<boolean>>>,
+    [content: string | MessageEditOptions | MessagePayload],
+    string
+  >;
+  const scrimDescription = "the description of the scrim";
+  const scrim = { dateTime: new Date(), discordChannel: "channel" } as Scrim;
+
+  beforeEach(() => {
+    staticValueMock = new StaticValueServiceMock();
+    message = {
+      edit: jest.fn(),
+    } as unknown as Message;
+    messageEditSpy = jest.spyOn(message, "edit");
+
+    forumChannel = {
+      fetchStarterMessage: () => Promise.resolve(message),
+      isThread: () => true,
+    } as unknown as ForumThreadChannel;
+
+    guild = {
+      channels: {
+        cache: {
+          get: () => forumChannel,
+        },
+      },
+    } as unknown as Guild;
+
+    client = {
+      guilds: {
+        cache: {
+          get: () => guild,
+        },
+      },
+    } as unknown as ExtendedClient;
+
+    discordService = new DiscordService(
+      client,
+      staticValueMock as StaticValueService,
+    );
+
+    jest
+      .spyOn(staticValueMock, "getInstructionText")
+      .mockReturnValue(Promise.resolve(scrimDescription));
+  });
+
+  it("Should update signup thread description", async () => {
+    const getGuildSpy = jest.spyOn(client.guilds.cache, "get");
+    const getForumThreadSpy = jest.spyOn(guild.channels.cache, "get");
+
+    await discordService.updateSignupPostDescription(scrim, 0);
+
+    expect(getGuildSpy).toHaveBeenCalledWith("a valid guild id");
+    expect(getForumThreadSpy).toHaveBeenCalledWith(scrim.discordChannel);
+    expect(messageEditSpy).toHaveBeenCalledWith(scrimDescription);
+  });
+
+  describe("errors", () => {
+    it("Should instruction text not found error", async () => {
+      jest
+        .spyOn(staticValueMock, "getInstructionText")
+        .mockReturnValueOnce(Promise.resolve(undefined));
+      const causeException = async () => {
+        await discordService.updateSignupPostDescription(scrim, 0);
+      };
+      await expect(causeException).rejects.toThrow(
+        "Instruction text not found",
+      );
+    });
+
+    it("Should throw guild not defined error", async () => {
+      jest.spyOn(client.guilds.cache, "get").mockReturnValueOnce(undefined);
+      const causeException = async () => {
+        await discordService.updateSignupPostDescription(scrim, 0);
+      };
+      await expect(causeException).rejects.toThrow("Guild not found");
+    });
+
+    describe("Not a valid channel error", () => {
+      it("Should throw signup thread not found error", async () => {
+        jest.spyOn(guild.channels.cache, "get").mockReturnValueOnce(undefined);
+
+        const causeException = async () => {
+          await discordService.updateSignupPostDescription(scrim, 0);
+        };
+        await expect(causeException).rejects.toThrow(
+          "Forum thread not found or not a valid thread",
+        );
+      });
+
+      it("Should throw signup thread is not a thread error", async () => {
+        jest.spyOn(forumChannel, "isThread").mockReturnValueOnce(false);
+
+        const causeException = async () => {
+          await discordService.updateSignupPostDescription(scrim, 0);
+        };
+        await expect(causeException).rejects.toThrow(
+          "Forum thread not found or not a valid thread",
+        );
+      });
+    });
+
+    it("Should throw no signup post description error", async () => {
+      jest
+        .spyOn(forumChannel, "fetchStarterMessage")
+        .mockReturnValueOnce(Promise.resolve(null));
+      const causeException = async () => {
+        await discordService.updateSignupPostDescription(scrim, 0);
+      };
+      await expect(causeException).rejects.toThrow(
+        "Signup post description not found",
+      );
+    });
+  });
+});

--- a/test/services/roster.test.ts
+++ b/test/services/roster.test.ts
@@ -5,18 +5,26 @@ import { CacheService } from "../../src/services/cache";
 import { RosterService } from "../../src/services/rosters";
 import { ScrimSignup, Scrim } from "../../src/models/Scrims";
 import { AuthService } from "../../src/services/auth";
+import { AuthMock } from "../mocks/auth.mock";
+import { DiscordServiceMock } from "../mocks/discord-service.mock";
+import { DiscordService } from "../../src/services/discord";
 
 describe("Rosters", () => {
   let dbMock: DbMock;
   let cache: CacheService;
   let rosters: RosterService;
-  let authService: AuthService;
+  let authService: AuthMock;
 
   beforeEach(() => {
     dbMock = new DbMock();
     cache = new CacheService();
-    authService = new AuthService(dbMock, cache);
-    rosters = new RosterService(dbMock, cache, authService);
+    authService = new AuthMock();
+    rosters = new RosterService(
+      dbMock,
+      cache,
+      authService as AuthService,
+      new DiscordServiceMock() as DiscordService,
+    );
     jest
       .spyOn(authService, "memberIsAdmin")
       .mockReturnValue(Promise.resolve(true));

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -14,6 +14,8 @@ import { PrioServiceMock } from "../mocks/prio.mock";
 import { AuthMock } from "../mocks/auth.mock";
 import { AuthService } from "../../src/services/auth";
 import { OverstatServiceMock } from "../mocks/overstat.mock";
+import { DiscordService } from "../../src/services/discord";
+import { DiscordServiceMock } from "../mocks/discord-service.mock";
 
 describe("Signups", () => {
   let dbMock: DbMock;
@@ -30,6 +32,7 @@ describe("Signups", () => {
     cache = new CacheService();
     overstatService = new OverstatServiceMock();
     prioServiceMock = new PrioServiceMock();
+
     authServiceMock = new AuthMock();
     signups = new ScrimSignups(
       dbMock,
@@ -37,6 +40,7 @@ describe("Signups", () => {
       overstatService as OverstatService,
       prioServiceMock as PrioService,
       authServiceMock as AuthService,
+      new DiscordServiceMock() as DiscordService,
     );
     insertPlayersSpy = jest.spyOn(dbMock, "insertPlayers");
     insertPlayersSpy.mockReturnValue(


### PR DESCRIPTION
* Include signup count in scrim information
  * signup and roster service now trigger the update when a team signs up or drops out
* Move scrim information variable replacement to the utility file
* Separate client invocation out of index file so it can be injected into the discord service
* New discord service that depends on the discord client
  * can perform discord actions without needing interaction context
* refactor warning of missing overstat for clarity 