### PR TITLE
feature/signup-disclose-prio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrim-bot",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrim-bot",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@nhost/nhost-js": "^3.1.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrim-bot",
   "description": "A multipurpose bot to track scrim signups, low prio and player performance among other things",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "author": "Jacob Heuman",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -43,7 +43,7 @@ export const commands: Command[] = [
 
   new ChangeTeamNameCommand(rosterService),
   new DropoutCommand(rosterService),
-  new SignupCommand(signupsService),
+  new SignupCommand(signupsService, prioService),
   new SubPlayerCommand(rosterService),
 
   new LinkOverstatCommand(authService, overstatService),

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -53,6 +53,10 @@ export class ScrimSignups {
     return scrimId;
   }
 
+  getScrim(discordChannelID: string): Scrim | undefined {
+    return this.cache.getScrim(discordChannelID);
+  }
+
   // this is a dynamic method that checks if scores have already been computed for a given discordChannel
   // if they have been computed it creates a new scrim entry in the db and computes stats for that one
   // this solves the problem of having multiple lobbies in one scrim.

--- a/test/mocks/signups.mock.ts
+++ b/test/mocks/signups.mock.ts
@@ -1,4 +1,4 @@
-import { ScrimSignup } from "../../src/models/Scrims";
+import { Scrim, ScrimSignup } from "../../src/models/Scrims";
 import { User } from "discord.js";
 
 export class ScrimSignupMock {
@@ -29,6 +29,11 @@ export class ScrimSignupMock {
   async closeScrim(discordChannelID: string) {
     console.log("Closing scrim in signup mock", discordChannelID);
     return Promise.resolve();
+  }
+
+  getScrim(discordChannelID: string): Scrim | undefined {
+    console.log("Getting scrim in signup mock", discordChannelID);
+    return undefined;
   }
 
   async addTeam(

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -17,6 +17,14 @@ import { OverstatServiceMock } from "../mocks/overstat.mock";
 import { DiscordService } from "../../src/services/discord";
 import { DiscordServiceMock } from "../mocks/discord-service.mock";
 
+jest.mock("../../src/config", () => {
+  return {
+    appConfig: {
+      lobbySize: 3,
+    },
+  };
+});
+
 describe("Signups", () => {
   let dbMock: DbMock;
   let cache: CacheService;


### PR DESCRIPTION
* Disclose any prio entries that will apply to scrim signup (Does not include scrim pass as thats applied when pulling signups for up to date info)
* Spy on config lobby size so actual config file doesn't effect the test