### PR TITLE
feature/league-signup-db-manage

### DIFF
--- a/nhost/nhost/metadata/databases/default/tables/public_league_seasons.yaml
+++ b/nhost/nhost/metadata/databases/default/tables/public_league_seasons.yaml
@@ -1,0 +1,3 @@
+table:
+  name: league_seasons
+  schema: public

--- a/nhost/nhost/metadata/databases/default/tables/tables.yaml
+++ b/nhost/nhost/metadata/databases/default/tables/tables.yaml
@@ -8,6 +8,7 @@
 - "!include auth_user_security_keys.yaml"
 - "!include auth_users.yaml"
 - "!include public_dummy_scrim_signups_with_players.yaml"
+- "!include public_league_seasons.yaml"
 - "!include public_lobby_event_times.yaml"
 - "!include public_players.yaml"
 - "!include public_prio.yaml"

--- a/nhost/nhost/migrations/default/1775931107818_create_table_public_league_seasons/down.sql
+++ b/nhost/nhost/migrations/default/1775931107818_create_table_public_league_seasons/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.league_seasons;

--- a/nhost/nhost/migrations/default/1775931107818_create_table_public_league_seasons/up.sql
+++ b/nhost/nhost/migrations/default/1775931107818_create_table_public_league_seasons/up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE public.league_seasons (id uuid DEFAULT gen_random_uuid() NOT NULL, name text UNIQUE NOT NULL, signup_start_date timestamptz NOT NULL, signup_prio_end_date timestamptz NOT NULL, signup_end_date timestamptz NOT NULL, start_date timestamptz NOT NULL, PRIMARY KEY (id));

--- a/nhost/nhost/migrations/default/1775931292313_alter_table_public_league_seasons/down.sql
+++ b/nhost/nhost/migrations/default/1775931292313_alter_table_public_league_seasons/down.sql
@@ -1,0 +1,5 @@
+-- Could not auto-generate a down migration
+-- Please write an appropriate down migration for the SQL below:
+-- ALTER TABLE public.league_seasons ADD google_sheet_id text NOT NULL;
+-- ALTER TABLE public.league_seasons ADD google_sheet_name text NOT NULL;
+-- ALTER TABLE public.league_seasons ADD google_sheet_range_start text NOT NULL;

--- a/nhost/nhost/migrations/default/1775931292313_alter_table_public_league_seasons/up.sql
+++ b/nhost/nhost/migrations/default/1775931292313_alter_table_public_league_seasons/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.league_seasons ADD google_sheet_id text NOT NULL;
+ALTER TABLE public.league_seasons ADD google_sheet_name text NOT NULL;
+ALTER TABLE public.league_seasons ADD google_sheet_range_start text NOT NULL;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrim-bot",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrim-bot",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@googleapis/sheets": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrim-bot",
   "description": "A multipurpose bot to track scrim signups, low prio and player performance among other things",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "author": "Jacob Heuman",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,6 +22,7 @@ import {
   scrimService,
   staticValueService,
   banService,
+  leagueSignupService,
 } from "../services";
 import { LinkOverstatCommand } from "./overstat/link-overstat";
 import { GetOverstatCommand } from "./overstat/get-overstat";
@@ -65,8 +66,7 @@ export const scrimCommands: Command[] = [
 ];
 
 export const leagueCommands: Command[] = [
-  new LeagueSignupCommand(overstatService),
-
+  new LeagueSignupCommand(overstatService, leagueSignupService),
   new RoleAssignmentCommand(authService),
 ];
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,7 +22,7 @@ import {
   scrimService,
   staticValueService,
   banService,
-  leagueSignupService,
+  leagueService,
 } from "../services";
 import { LinkOverstatCommand } from "./overstat/link-overstat";
 import { GetOverstatCommand } from "./overstat/get-overstat";
@@ -66,7 +66,7 @@ export const scrimCommands: Command[] = [
 ];
 
 export const leagueCommands: Command[] = [
-  new LeagueSignupCommand(overstatService, leagueSignupService),
+  new LeagueSignupCommand(overstatService, leagueService),
   new RoleAssignmentCommand(authService),
 ];
 

--- a/src/commands/league/league-signup.ts
+++ b/src/commands/league/league-signup.ts
@@ -2,12 +2,14 @@ import { MemberCommand } from "../command";
 import { CustomInteraction } from "../interaction";
 import { isGuildMember } from "../../utility/utility";
 import { OverstatService } from "../../services/overstat";
-import { Snowflake, User } from "discord.js";
-import { GoogleAuth, OAuth2Client } from "googleapis-common";
-import { AnyAuthClient } from "google-auth-library";
-import { auth, sheets } from "@googleapis/sheets";
-import { SheetHelper } from "../../utility/sheet-helper";
-import { DB } from "../../db/db";
+import { User } from "discord.js";
+import {
+  LeagueSignupService,
+  SheetsPlayer,
+  PlayerRank,
+  Platform,
+  VesaDivision,
+} from "../../services/league-signup";
 
 export class LeagueSignupCommand extends MemberCommand {
   inputNames = {
@@ -43,7 +45,7 @@ export class LeagueSignupCommand extends MemberCommand {
 
   constructor(
     private overstatService: OverstatService,
-    private db: DB,
+    private leagueSignupService: LeagueSignupService,
   ) {
     super("league-signup", "Signup for the league");
     this.addStringInput(this.inputNames.teamName, "Team name", {
@@ -219,7 +221,7 @@ export class LeagueSignupCommand extends MemberCommand {
     await interaction.deferReply();
 
     try {
-      const signupNumber = await this.postSpreadSheetValue(
+      const signupNumber = await this.leagueSignupService.signup(
         teamName,
         teamNoDays ?? "Open schedule",
         compExperience,
@@ -324,124 +326,4 @@ export class LeagueSignupCommand extends MemberCommand {
     }
     return linkToReturn;
   }
-
-  async postSpreadSheetValue(
-    teamName: string,
-    teamNoDays: string,
-    teamCompKnowledge: string,
-    player1: SheetsPlayer,
-    player2: SheetsPlayer,
-    player3: SheetsPlayer,
-    additionalComments: string,
-  ): Promise<number | null> {
-    const authClient = await this.getAuthClient();
-
-    const returningPlayersCount = [player1, player2, player3].reduce(
-      (count, player) => {
-        if (player.previous_season_vesa_division !== VesaDivision.None) {
-          return count + 1;
-        } else {
-          return count;
-        }
-      },
-      0,
-    );
-    const values = [
-      [
-        new Date().toISOString(),
-        teamName,
-        teamNoDays,
-        teamCompKnowledge,
-        `${returningPlayersCount} returning players`,
-        ...this.convertSheetsPlayer(player1),
-        ...this.convertSheetsPlayer(player2),
-        ...this.convertSheetsPlayer(player3),
-        additionalComments,
-      ],
-    ];
-
-    const sheetsClient = sheets({ version: "v4" });
-    const activeSeason = await this.db.getActiveLeagueSeason();
-    if (!activeSeason) {
-      throw new Error("No season found with active signups.");
-    }
-    const request = SheetHelper.BUILD_REQUEST(
-      values,
-      authClient as OAuth2Client,
-      {
-        id: activeSeason.googleSheetId,
-        range: `${activeSeason.googleSheetName}!${activeSeason.googleSheetRangeStart}`,
-      },
-    );
-
-    const response = await sheetsClient.spreadsheets.values.append(request);
-    console.log(response.data);
-    const rowNumber = SheetHelper.GET_ROW_NUMBER_FROM_UPDATE_RESPONSE(
-      response.data.updates,
-    );
-    return rowNumber ? rowNumber - SheetHelper.STARTING_CELL_OFFSET : null;
-  }
-
-  private convertSheetsPlayer(player: SheetsPlayer): (string | number)[] {
-    return [
-      player.name,
-      player.discordId,
-      player.overstatLink ?? "No overstat",
-      VesaDivision[player.previous_season_vesa_division],
-      PlayerRank[player.rank],
-      Platform[player.platform],
-      player.elo ?? "No elo on record",
-    ];
-  }
-
-  getAuthClient(): Promise<AnyAuthClient> {
-    const googleAuth = new auth.GoogleAuth({
-      keyFile: "service-account-key.json",
-      scopes: ["https://www.googleapis.com/auth/spreadsheets"],
-    }) as GoogleAuth;
-
-    return googleAuth.getClient();
-  }
-}
-
-enum PlayerRank {
-  Bronze,
-  Silver,
-  Gold,
-  Plat,
-  LowDiamond,
-  HighDiamond,
-  Masters,
-  Pred,
-}
-
-enum VesaDivision {
-  None,
-  Division1,
-  Division2,
-  Division3,
-  Division4,
-  Division5,
-  Division6,
-  Division7,
-  // Division8,
-  // Division9,
-  // Division10,
-}
-
-enum Platform {
-  pc,
-  playstation,
-  xbox,
-  switch,
-}
-
-interface SheetsPlayer {
-  name: string;
-  discordId: Snowflake;
-  elo: number | undefined;
-  rank: PlayerRank;
-  previous_season_vesa_division: VesaDivision;
-  platform: Platform;
-  overstatLink: string | undefined;
 }

--- a/src/commands/league/league-signup.ts
+++ b/src/commands/league/league-signup.ts
@@ -45,7 +45,7 @@ export class LeagueSignupCommand extends MemberCommand {
 
   constructor(
     private overstatService: OverstatService,
-    private leagueSignupService: LeagueService,
+    private leagueService: LeagueService,
   ) {
     super("league-signup", "Signup for the league");
     this.addStringInput(this.inputNames.teamName, "Team name", {
@@ -221,7 +221,7 @@ export class LeagueSignupCommand extends MemberCommand {
     await interaction.deferReply();
 
     try {
-      const signupNumber = await this.leagueSignupService.signup(
+      const signupNumber = await this.leagueService.signup(
         teamName,
         teamNoDays ?? "Open schedule",
         compExperience,

--- a/src/commands/league/league-signup.ts
+++ b/src/commands/league/league-signup.ts
@@ -6,7 +6,8 @@ import { Snowflake, User } from "discord.js";
 import { GoogleAuth, OAuth2Client } from "googleapis-common";
 import { AnyAuthClient } from "google-auth-library";
 import { auth, sheets } from "@googleapis/sheets";
-import { SheetHelper, SpreadSheetType } from "../../utility/sheet-helper";
+import { SheetHelper } from "../../utility/sheet-helper";
+import { DB } from "../../db/db";
 
 export class LeagueSignupCommand extends MemberCommand {
   inputNames = {
@@ -40,7 +41,10 @@ export class LeagueSignupCommand extends MemberCommand {
     comments: "additional-comments",
   };
 
-  constructor(private overstatService: OverstatService) {
+  constructor(
+    private overstatService: OverstatService,
+    private db: DB,
+  ) {
     super("league-signup", "Signup for the league");
     this.addStringInput(this.inputNames.teamName, "Team name", {
       isRequired: true,
@@ -356,13 +360,20 @@ export class LeagueSignupCommand extends MemberCommand {
       ],
     ];
 
+    const sheetsClient = sheets({ version: "v4" });
+    const activeSeason = await this.db.getActiveLeagueSeason();
+    if (!activeSeason) {
+      throw new Error("No season found with active signups.");
+    }
     const request = SheetHelper.BUILD_REQUEST(
       values,
       authClient as OAuth2Client,
-      SpreadSheetType.PROD_SHEET,
+      {
+        id: activeSeason.googleSheetId,
+        range: `${activeSeason.googleSheetName}!${activeSeason.googleSheetRangeStart}`,
+      },
     );
 
-    const sheetsClient = sheets({ version: "v4" });
     const response = await sheetsClient.spreadsheets.values.append(request);
     console.log(response.data);
     const rowNumber = SheetHelper.GET_ROW_NUMBER_FROM_UPDATE_RESPONSE(

--- a/src/commands/league/league-signup.ts
+++ b/src/commands/league/league-signup.ts
@@ -4,7 +4,7 @@ import { isGuildMember } from "../../utility/utility";
 import { OverstatService } from "../../services/overstat";
 import { User } from "discord.js";
 import {
-  LeagueSignupService,
+  LeagueService,
   SheetsPlayer,
   PlayerRank,
   Platform,
@@ -45,7 +45,7 @@ export class LeagueSignupCommand extends MemberCommand {
 
   constructor(
     private overstatService: OverstatService,
-    private leagueSignupService: LeagueSignupService,
+    private leagueSignupService: LeagueService,
   ) {
     super("league-signup", "Signup for the league");
     this.addStringInput(this.inputNames.teamName, "Team name", {

--- a/src/commands/league/league-signup.ts
+++ b/src/commands/league/league-signup.ts
@@ -221,7 +221,7 @@ export class LeagueSignupCommand extends MemberCommand {
     await interaction.deferReply();
 
     try {
-      const signupNumber = await this.leagueService.signup(
+      const signupResult = await this.leagueService.signup(
         teamName,
         teamNoDays ?? "Open schedule",
         compExperience,
@@ -230,7 +230,7 @@ export class LeagueSignupCommand extends MemberCommand {
         player3,
         additionalComments ?? "",
       );
-      if (signupNumber === null) {
+      if (!signupResult) {
         await interaction.followUp(
           "Problem parsing google sheets response, please check sheet to see if your signup went through before resubmitting",
         );
@@ -243,8 +243,20 @@ export class LeagueSignupCommand extends MemberCommand {
           discordId: signupPlayer.id,
         },
       });
+
+      let additionalInfo = "";
+      const currentDate = new Date();
+      if (new Date(signupResult.seasonInfo.startDate) < currentDate) {
+        additionalInfo =
+          "\nThe season is already ongoing, the team will be placed on the waitlist to fill in for teams that drop out.";
+      } else if (
+        new Date(signupResult.seasonInfo.signupPrioEndDate) < currentDate
+      ) {
+        additionalInfo = "\nSignup occurred after the priority window ended.";
+      }
+
       await interaction.followUp(
-        `${signupString}\nSignup #${signupNumber}. Your priority based on returning players will be determined by admins manually`,
+        `${signupString}\nSignup #${signupResult.rowNumber}. Your priority based on returning players will be determined by admins manually${additionalInfo}`,
       );
     } catch (e) {
       await interaction.followUp(`Team not signed up. ${e}`);

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -395,6 +395,8 @@ export abstract class DB {
     googleSheetId: string;
     googleSheetName: string;
     googleSheetRangeStart: string;
+    signupPrioEndDate: string;
+    startDate: string;
   } | null> {
     const dbData = await this.get(
       DbTable.leagueSeasons,
@@ -418,6 +420,8 @@ export abstract class DB {
         "google_sheet_id",
         "google_sheet_name",
         "google_sheet_range_start",
+        "signup_prio_end_date",
+        "start_date",
       ],
     );
 
@@ -427,6 +431,8 @@ export abstract class DB {
         googleSheetId: dbData[0].google_sheet_id as string,
         googleSheetName: dbData[0].google_sheet_name as string,
         googleSheetRangeStart: dbData[0].google_sheet_range_start as string,
+        signupPrioEndDate: dbData[0].signup_prio_end_date as string,
+        startDate: dbData[0].start_date as string,
       };
     } else {
       return null;

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -390,6 +390,49 @@ export abstract class DB {
     >;
   }
 
+  async getActiveLeagueSeason(date: Date = new Date()): Promise<{
+    id: string;
+    googleSheetId: string;
+    googleSheetName: string;
+    googleSheetRangeStart: string;
+  } | null> {
+    const dbData = await this.get(
+      DbTable.leagueSeasons,
+      {
+        operator: "and",
+        expressions: [
+          {
+            fieldName: "signup_start_date",
+            comparator: "lte",
+            value: date,
+          },
+          {
+            fieldName: "signup_end_date",
+            comparator: "gte",
+            value: date,
+          },
+        ],
+      },
+      [
+        "id",
+        "google_sheet_id",
+        "google_sheet_name",
+        "google_sheet_range_start",
+      ],
+    );
+
+    if (dbData.length > 0) {
+      return {
+        id: dbData[0].id as string,
+        googleSheetId: dbData[0].google_sheet_id as string,
+        googleSheetName: dbData[0].google_sheet_name as string,
+        googleSheetRangeStart: dbData[0].google_sheet_range_start as string,
+      };
+    } else {
+      return null;
+    }
+  }
+
   async getScrimSignupsWithPlayers(
     scrimId: string,
   ): Promise<ScrimSignupsWithPlayers[]> {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -29,6 +29,7 @@ export enum DbTable {
   scrimBans = "scrim_bans",
   staticKeyValues = "static_key_value",
   lobbyEventTimes = "lobby_event_times",
+  leagueSeasons = "league_seasons",
 }
 
 // Recursive type to infer the return structure

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,7 +10,7 @@ import { DiscordService } from "./discord";
 import { client } from "../Client";
 import { BanService } from "./ban";
 import { HuggingFaceService } from "./hugging-face";
-import { LeagueSignupService } from "./league-signup";
+import { LeagueService } from "./league-signup";
 
 // This file creates all the singleton services
 export const huggingFaceService = new HuggingFaceService();
@@ -44,4 +44,4 @@ export const rosterService = new RosterService(
   scrimService,
   signupsService,
 );
-export const leagueSignupService = new LeagueSignupService(nhostDb);
+export const leagueService = new LeagueService(nhostDb);

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -10,6 +10,7 @@ import { DiscordService } from "./discord";
 import { client } from "../Client";
 import { BanService } from "./ban";
 import { HuggingFaceService } from "./hugging-face";
+import { LeagueSignupService } from "./league-signup";
 
 // This file creates all the singleton services
 export const huggingFaceService = new HuggingFaceService();
@@ -43,3 +44,4 @@ export const rosterService = new RosterService(
   scrimService,
   signupsService,
 );
+export const leagueSignupService = new LeagueSignupService(nhostDb);

--- a/src/services/league-signup.ts
+++ b/src/services/league-signup.ts
@@ -47,7 +47,7 @@ export interface SheetsPlayer {
   overstatLink: string | undefined;
 }
 
-export class LeagueSignupService {
+export class LeagueService {
   constructor(private db: DB) {}
 
   async signup(

--- a/src/services/league-signup.ts
+++ b/src/services/league-signup.ts
@@ -47,6 +47,14 @@ export interface SheetsPlayer {
   overstatLink: string | undefined;
 }
 
+export interface SignupResult {
+  rowNumber: number;
+  seasonInfo: {
+    signupPrioEndDate: string;
+    startDate: string;
+  };
+}
+
 export class LeagueService {
   constructor(private db: DB) {}
 
@@ -58,7 +66,7 @@ export class LeagueService {
     player2: SheetsPlayer,
     player3: SheetsPlayer,
     additionalComments: string,
-  ): Promise<number | null> {
+  ): Promise<SignupResult | null> {
     const authClient = await this.getAuthClient();
 
     const returningPlayersCount = [player1, player2, player3].reduce(
@@ -104,7 +112,18 @@ export class LeagueService {
     const rowNumber = SheetHelper.GET_ROW_NUMBER_FROM_UPDATE_RESPONSE(
       response.data.updates,
     );
-    return rowNumber ? rowNumber - SheetHelper.STARTING_CELL_OFFSET : null;
+
+    if (!rowNumber) {
+      return null;
+    } else {
+      return {
+        rowNumber: rowNumber - SheetHelper.STARTING_CELL_OFFSET,
+        seasonInfo: {
+          signupPrioEndDate: activeSeason.signupPrioEndDate,
+          startDate: activeSeason.startDate,
+        },
+      };
+    }
   }
 
   private convertSheetsPlayer(player: SheetsPlayer): (string | number)[] {

--- a/src/services/league-signup.ts
+++ b/src/services/league-signup.ts
@@ -1,0 +1,130 @@
+import { Snowflake } from "discord.js";
+import { GoogleAuth, OAuth2Client } from "googleapis-common";
+import { AnyAuthClient } from "google-auth-library";
+import { auth, sheets } from "@googleapis/sheets";
+import { SheetHelper } from "../utility/sheet-helper";
+import { DB } from "../db/db";
+
+export enum PlayerRank {
+  Bronze,
+  Silver,
+  Gold,
+  Plat,
+  LowDiamond,
+  HighDiamond,
+  Masters,
+  Pred,
+}
+
+export enum VesaDivision {
+  None,
+  Division1,
+  Division2,
+  Division3,
+  Division4,
+  Division5,
+  Division6,
+  Division7,
+  // Division8,
+  // Division9,
+  // Division10,
+}
+
+export enum Platform {
+  pc,
+  playstation,
+  xbox,
+  switch,
+}
+
+export interface SheetsPlayer {
+  name: string;
+  discordId: Snowflake;
+  elo: number | undefined;
+  rank: PlayerRank;
+  previous_season_vesa_division: VesaDivision;
+  platform: Platform;
+  overstatLink: string | undefined;
+}
+
+export class LeagueSignupService {
+  constructor(private db: DB) {}
+
+  async signup(
+    teamName: string,
+    teamNoDays: string,
+    teamCompKnowledge: string,
+    player1: SheetsPlayer,
+    player2: SheetsPlayer,
+    player3: SheetsPlayer,
+    additionalComments: string,
+  ): Promise<number | null> {
+    const authClient = await this.getAuthClient();
+
+    const returningPlayersCount = [player1, player2, player3].reduce(
+      (count, player) => {
+        if (player.previous_season_vesa_division !== VesaDivision.None) {
+          return count + 1;
+        } else {
+          return count;
+        }
+      },
+      0,
+    );
+    const values = [
+      [
+        new Date().toISOString(),
+        teamName,
+        teamNoDays,
+        teamCompKnowledge,
+        `${returningPlayersCount} returning players`,
+        ...this.convertSheetsPlayer(player1),
+        ...this.convertSheetsPlayer(player2),
+        ...this.convertSheetsPlayer(player3),
+        additionalComments,
+      ],
+    ];
+
+    const sheetsClient = sheets({ version: "v4" });
+    const activeSeason = await this.db.getActiveLeagueSeason();
+    if (!activeSeason) {
+      throw new Error("No season found with active signups.");
+    }
+    const request = SheetHelper.BUILD_REQUEST(
+      values,
+      authClient as OAuth2Client,
+      {
+        id: activeSeason.googleSheetId,
+        range: `${activeSeason.googleSheetName}!${activeSeason.googleSheetRangeStart}`,
+      },
+    );
+
+    const response = await sheetsClient.spreadsheets.values.append(request);
+    console.log(response.data);
+    const rowNumber = SheetHelper.GET_ROW_NUMBER_FROM_UPDATE_RESPONSE(
+      response.data.updates,
+    );
+    return rowNumber ? rowNumber - SheetHelper.STARTING_CELL_OFFSET : null;
+  }
+
+  private convertSheetsPlayer(player: SheetsPlayer): (string | number)[] {
+    return [
+      player.name,
+      player.discordId,
+      player.overstatLink ?? "No overstat",
+      VesaDivision[player.previous_season_vesa_division],
+      PlayerRank[player.rank],
+      Platform[player.platform],
+      player.elo ?? "No elo on record",
+    ];
+  }
+
+  private getAuthClient(): Promise<AnyAuthClient> {
+    const googleAuth = new auth.GoogleAuth({
+      keyFile: "service-account-key.json",
+      scopes: ["https://www.googleapis.com/auth/spreadsheets"],
+    }) as GoogleAuth;
+
+    return googleAuth.getClient();
+  }
+}

--- a/src/utility/sheet-helper.ts
+++ b/src/utility/sheet-helper.ts
@@ -3,25 +3,6 @@ import { sheets_v4 } from "@googleapis/sheets";
 import Schema$UpdateValuesResponse = sheets_v4.Schema$UpdateValuesResponse;
 import Params$Resource$Spreadsheets$Values$Append = sheets_v4.Params$Resource$Spreadsheets$Values$Append;
 
-enum SpreadSheetTypes {
-  TEST_SHEET = "TEST_SHEET",
-  PROD_SHEET = "PROD_SHEET",
-}
-
-export const SpreadSheetType: Record<
-  SpreadSheetTypes,
-  { id: string; range: string }
-> = {
-  TEST_SHEET: {
-    id: "1_e_TdsjAc077eHSzcAOVs8xBHAJSPVd9JXJiLDfVHeo",
-    range: "Sheet1!A1",
-  },
-  PROD_SHEET: {
-    id: "1pp8ynvVj9Z1yuuNhy8C2QvyflYhWhAQC3BQD_OJXkn4",
-    range: "Discord Submittals!A1",
-  },
-};
-
 export class SheetHelper {
   static STARTING_CELL_OFFSET = 1;
 

--- a/test/commands/league/league-signup.test.ts
+++ b/test/commands/league/league-signup.test.ts
@@ -22,6 +22,7 @@ import Resource$Spreadsheets = GoogleSheets.sheets_v4.Resource$Spreadsheets;
 import Sheets = GoogleSheets.sheets_v4.Sheets;
 import Params$Resource$Spreadsheets$Values$Append = GoogleSheets.sheets_v4.Params$Resource$Spreadsheets$Values$Append;
 import { DB } from "../../../src/db/db";
+import { DbMock } from "../../mocks/db.mock";
 
 class MockGoogleAuth {
   getClient() {
@@ -44,6 +45,16 @@ describe("Sign up", () => {
   let googleSheetsRequestSpy: SpyInstance<
     Promise<GaxiosResponseWithHTTP2<Readable>>,
     [request: Params$Resource$Spreadsheets$Values$Append],
+    string
+  >;
+  let dbGetActiveLeagueSeasonSpy: SpyInstance<
+    Promise<{
+      id: string;
+      googleSheetId: string;
+      googleSheetName: string;
+      googleSheetRangeStart: string;
+    } | null>,
+    [date?: Date],
     string
   >;
   let getPlayerOverstatSpy: SpyInstance;
@@ -73,11 +84,14 @@ describe("Sign up", () => {
   } as User;
 
   let mockOverstatService: OverstatService;
+  let mockDb: DbMock;
 
   beforeAll(() => {
     mockOverstatService = new OverstatServiceMock() as OverstatService;
+    mockDb = new DbMock();
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
+      mockDb,
     );
     basicInteraction = {
       channelId: "forum thread id",
@@ -152,17 +166,30 @@ describe("Sign up", () => {
           overstatLink,
         );
       });
+    dbGetActiveLeagueSeasonSpy = jest.spyOn(mockDb, "getActiveLeagueSeason");
+    dbGetActiveLeagueSeasonSpy.mockReturnValue(
+      Promise.resolve({
+        id: "1",
+        googleSheetId: "google_sheet_id",
+        googleSheetName: "tab_name",
+        googleSheetRangeStart: "A1",
+      }),
+    );
   });
 
   beforeEach(() => {
-    followUpSpy.mockClear();
-    googleSheetsRequestSpy.mockClear();
-    command = new LeagueSignupCommand(mockOverstatService);
+    command = new LeagueSignupCommand(mockOverstatService, mockDb);
     getPlayerOverstatSpy = jest
       .spyOn(mockOverstatService, "getPlayerOverstat")
       .mockImplementation(() => {
         throw Error("Rejected get player overstat promise");
       });
+    followUpSpy.mockClear();
+    googleSheetsRequestSpy.mockClear();
+    invisibleReplySpy.mockClear();
+    dbGetActiveLeagueSeasonSpy.mockClear();
+    getPlayerOverstatSpy.mockClear();
+    googleSheetsSpy.mockClear();
   });
 
   it("Should complete signup", async () => {
@@ -172,7 +199,7 @@ describe("Sign up", () => {
     await command.run(basicInteraction);
     expect(googleSheetsRequestSpy).toHaveBeenCalledWith({
       auth: undefined,
-      range: "Discord Submittals!A1",
+      range: "tab_name!A1",
       requestBody: {
         values: [
           [
@@ -206,7 +233,7 @@ describe("Sign up", () => {
           ],
         ],
       },
-      spreadsheetId: "1pp8ynvVj9Z1yuuNhy8C2QvyflYhWhAQC3BQD_OJXkn4",
+      spreadsheetId: "google_sheet_id",
       valueInputOption: "USER_ENTERED",
     });
     expect(followUpSpy).toHaveBeenCalledWith(
@@ -234,7 +261,7 @@ describe("Sign up", () => {
     await command.run(basicInteraction);
     expect(googleSheetsRequestSpy).toHaveBeenCalledWith({
       auth: undefined,
-      range: "Discord Submittals!A1",
+      range: "tab_name!A1",
       requestBody: {
         values: [
           [
@@ -268,7 +295,7 @@ describe("Sign up", () => {
           ],
         ],
       },
-      spreadsheetId: "1pp8ynvVj9Z1yuuNhy8C2QvyflYhWhAQC3BQD_OJXkn4",
+      spreadsheetId: "google_sheet_id",
       valueInputOption: "USER_ENTERED",
     });
     expect(followUpSpy).toHaveBeenCalledWith(
@@ -344,7 +371,15 @@ describe("Sign up", () => {
       );
     });
 
-    it("Should complete signup with db filled overstat", async () => {
+    it("should not complete the signup because the no active league season", async () => {
+      dbGetActiveLeagueSeasonSpy.mockReturnValueOnce(Promise.resolve(null));
+      await command.run(basicInteraction);
+      expect(followUpSpy).toHaveBeenCalledWith(
+        `Team not signed up. Error: No season found with active signups.`,
+      );
+    });
+
+    it("Should not complete signup since overstat link is not valid", async () => {
       getPlayerOverstatSpy.mockReturnValue(
         Promise.resolve(getPlayerOverstatUrl("123")),
       );
@@ -393,6 +428,7 @@ describe("Sign up", () => {
   const getPlayerRank = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
+      new DbMock(),
     );
     if (
       key ===
@@ -419,6 +455,7 @@ describe("Sign up", () => {
   const getPlayerDivision = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
+      new DbMock(),
     );
     if (
       key ===
@@ -448,6 +485,7 @@ describe("Sign up", () => {
   const getPlayerOverstat = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
+      new DbMock(),
     );
     if (
       key ===
@@ -477,6 +515,7 @@ describe("Sign up", () => {
   const getPlayerPlatform = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
+      new DbMock(),
     );
     if (
       key ===

--- a/test/commands/league/league-signup.test.ts
+++ b/test/commands/league/league-signup.test.ts
@@ -109,7 +109,13 @@ describe("Sign up", () => {
     } as unknown as CustomInteraction;
     followUpSpy = jest.spyOn(basicInteraction, "followUp");
     invisibleReplySpy = jest.spyOn(basicInteraction, "invisibleReply");
-    signupSpy = jest.spyOn(mockLeagueService, "signup").mockResolvedValue(0);
+    signupSpy = jest.spyOn(mockLeagueService, "signup").mockResolvedValue({
+      rowNumber: 0,
+      seasonInfo: {
+        signupPrioEndDate: new Date("2026-01-01T00:00:00Z").toISOString(),
+        startDate: new Date("2026-02-01T00:00:00Z").toISOString(),
+      },
+    });
 
     jest
       .spyOn(mockOverstatService, "getPlayerId")
@@ -242,6 +248,44 @@ describe("Sign up", () => {
     expect(followUpSpy).toHaveBeenCalledWith(
       `Problem parsing google sheets response, please check sheet to see if your signup went through before resubmitting`,
     );
+  });
+
+  it("Should complete signup and warn that season is ongoing", async () => {
+    signupSpy.mockResolvedValueOnce({
+      rowNumber: 0,
+      seasonInfo: {
+        signupPrioEndDate: new Date("2025-10-01T00:00:00Z").toISOString(),
+        startDate: new Date("2025-11-01T00:00:00Z").toISOString(),
+      },
+    });
+    const date = new Date("2025-12-26T18:55:23.264Z");
+    jest.useFakeTimers();
+    jest.setSystemTime(date);
+
+    await command.run(basicInteraction);
+    expect(followUpSpy).toHaveBeenCalledWith(
+      `__team name__\nSigned up by: <@player1id>.\nPlayers: <@player1id>, <@player2id>, <@player3id>.\nSignup #0. Your priority based on returning players will be determined by admins manually\nThe season is already ongoing, the team will be placed on the waitlist to fill in for teams that drop out.`,
+    );
+    jest.useRealTimers();
+  });
+
+  it("Should complete signup and warn about priority date", async () => {
+    signupSpy.mockResolvedValueOnce({
+      rowNumber: 0,
+      seasonInfo: {
+        signupPrioEndDate: new Date("2025-11-01T00:00:00Z").toISOString(),
+        startDate: new Date("2026-01-01T00:00:00Z").toISOString(),
+      },
+    });
+    const date = new Date("2025-12-26T18:55:23.264Z");
+    jest.useFakeTimers();
+    jest.setSystemTime(date);
+
+    await command.run(basicInteraction);
+    expect(followUpSpy).toHaveBeenCalledWith(
+      `__team name__\nSigned up by: <@player1id>.\nPlayers: <@player1id>, <@player2id>, <@player3id>.\nSignup #0. Your priority based on returning players will be determined by admins manually\nSignup occurred after the priority window ended.`,
+    );
+    jest.useRealTimers();
   });
 
   describe("errors", () => {

--- a/test/commands/league/league-signup.test.ts
+++ b/test/commands/league/league-signup.test.ts
@@ -9,6 +9,7 @@ import {
 import SpyInstance = jest.SpyInstance;
 import { CustomInteraction } from "../../../src/commands/interaction";
 import { LeagueSignupCommand } from "../../../src/commands/league/league-signup";
+import { LeagueSignupService } from "../../../src/services/league-signup";
 import * as GoogleSheets from "@googleapis/sheets";
 
 import { GaxiosResponseWithHTTP2, GoogleAuth } from "googleapis-common";
@@ -91,7 +92,7 @@ describe("Sign up", () => {
     mockDb = new DbMock();
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      mockDb,
+      new LeagueSignupService(mockDb),
     );
     basicInteraction = {
       channelId: "forum thread id",
@@ -178,7 +179,10 @@ describe("Sign up", () => {
   });
 
   beforeEach(() => {
-    command = new LeagueSignupCommand(mockOverstatService, mockDb);
+    command = new LeagueSignupCommand(
+      mockOverstatService,
+      new LeagueSignupService(mockDb),
+    );
     getPlayerOverstatSpy = jest
       .spyOn(mockOverstatService, "getPlayerOverstat")
       .mockImplementation(() => {
@@ -428,7 +432,7 @@ describe("Sign up", () => {
   const getPlayerRank = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new DbMock(),
+      new LeagueSignupService(new DbMock()),
     );
     if (
       key ===
@@ -455,7 +459,7 @@ describe("Sign up", () => {
   const getPlayerDivision = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new DbMock(),
+      new LeagueSignupService(new DbMock()),
     );
     if (
       key ===
@@ -485,7 +489,7 @@ describe("Sign up", () => {
   const getPlayerOverstat = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new DbMock(),
+      new LeagueSignupService(new DbMock()),
     );
     if (
       key ===
@@ -515,7 +519,7 @@ describe("Sign up", () => {
   const getPlayerPlatform = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new DbMock(),
+      new LeagueSignupService(new DbMock()),
     );
     if (
       key ===

--- a/test/commands/league/league-signup.test.ts
+++ b/test/commands/league/league-signup.test.ts
@@ -9,27 +9,14 @@ import {
 import SpyInstance = jest.SpyInstance;
 import { CustomInteraction } from "../../../src/commands/interaction";
 import { LeagueSignupCommand } from "../../../src/commands/league/league-signup";
-import { LeagueSignupService } from "../../../src/services/league-signup";
-import * as GoogleSheets from "@googleapis/sheets";
-
-import { GaxiosResponseWithHTTP2, GoogleAuth } from "googleapis-common";
-import { Readable } from "stream";
-import { OverstatServiceMock } from "../../mocks/overstat.mock";
+import { LeagueService } from "../../../src/services/league-signup";
+import { LeagueServiceMock } from "../../mocks/league.mock";
 import {
   getPlayerOverstatUrl,
   OverstatService,
 } from "../../../src/services/overstat";
-import Resource$Spreadsheets = GoogleSheets.sheets_v4.Resource$Spreadsheets;
-import Sheets = GoogleSheets.sheets_v4.Sheets;
-import Params$Resource$Spreadsheets$Values$Append = GoogleSheets.sheets_v4.Params$Resource$Spreadsheets$Values$Append;
+import { OverstatServiceMock } from "../../mocks/overstat.mock";
 import { DB } from "../../../src/db/db";
-import { DbMock } from "../../mocks/db.mock";
-
-class MockGoogleAuth {
-  getClient() {
-    return undefined;
-  }
-}
 
 describe("Sign up", () => {
   let basicInteraction: CustomInteraction;
@@ -43,23 +30,8 @@ describe("Sign up", () => {
     [message: string],
     string
   >;
-  let googleSheetsRequestSpy: SpyInstance<
-    Promise<GaxiosResponseWithHTTP2<Readable>>,
-    [request: Params$Resource$Spreadsheets$Values$Append],
-    string
-  >;
-  let dbGetActiveLeagueSeasonSpy: SpyInstance<
-    Promise<{
-      id: string;
-      googleSheetId: string;
-      googleSheetName: string;
-      googleSheetRangeStart: string;
-    } | null>,
-    [date?: Date],
-    string
-  >;
   let getPlayerOverstatSpy: SpyInstance;
-  let googleSheetsSpy: SpyInstance;
+  let signupSpy: SpyInstance;
 
   let command: LeagueSignupCommand;
 
@@ -85,14 +57,14 @@ describe("Sign up", () => {
   } as User;
 
   let mockOverstatService: OverstatService;
-  let mockDb: DbMock;
+  let mockLeagueService: LeagueService;
 
   beforeAll(() => {
     mockOverstatService = new OverstatServiceMock() as OverstatService;
-    mockDb = new DbMock();
+    mockLeagueService = new LeagueServiceMock() as unknown as LeagueService;
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new LeagueSignupService(mockDb),
+      mockLeagueService,
     );
     basicInteraction = {
       channelId: "forum thread id",
@@ -137,29 +109,8 @@ describe("Sign up", () => {
     } as unknown as CustomInteraction;
     followUpSpy = jest.spyOn(basicInteraction, "followUp");
     invisibleReplySpy = jest.spyOn(basicInteraction, "invisibleReply");
+    signupSpy = jest.spyOn(mockLeagueService, "signup").mockResolvedValue(0);
 
-    const googleValuesMethods = {
-      append: (
-        request: Params$Resource$Spreadsheets$Values$Append,
-      ): Promise<GaxiosResponseWithHTTP2<Readable>> =>
-        Promise.resolve({
-          data: {
-            updates: {
-              updatedRange: "'Discord Submittals'!A1:Y1",
-            },
-            request: "Request data " + request.key,
-          },
-        } as GaxiosResponseWithHTTP2),
-    };
-    googleSheetsRequestSpy = jest.spyOn(googleValuesMethods, "append");
-    googleSheetsSpy = jest.spyOn(GoogleSheets, "sheets").mockReturnValue({
-      spreadsheets: {
-        values: googleValuesMethods,
-      } as unknown as Resource$Spreadsheets,
-    } as Sheets);
-    jest
-      .spyOn(GoogleSheets.auth, "GoogleAuth")
-      .mockReturnValue(new MockGoogleAuth() as unknown as GoogleAuth);
     jest
       .spyOn(mockOverstatService, "getPlayerId")
       .mockImplementation((overstatLink) => {
@@ -167,33 +118,19 @@ describe("Sign up", () => {
           overstatLink,
         );
       });
-    dbGetActiveLeagueSeasonSpy = jest.spyOn(mockDb, "getActiveLeagueSeason");
-    dbGetActiveLeagueSeasonSpy.mockReturnValue(
-      Promise.resolve({
-        id: "1",
-        googleSheetId: "google_sheet_id",
-        googleSheetName: "tab_name",
-        googleSheetRangeStart: "A1",
-      }),
-    );
   });
 
   beforeEach(() => {
-    command = new LeagueSignupCommand(
-      mockOverstatService,
-      new LeagueSignupService(mockDb),
-    );
+    command = new LeagueSignupCommand(mockOverstatService, mockLeagueService);
     getPlayerOverstatSpy = jest
       .spyOn(mockOverstatService, "getPlayerOverstat")
       .mockImplementation(() => {
         throw Error("Rejected get player overstat promise");
       });
     followUpSpy.mockClear();
-    googleSheetsRequestSpy.mockClear();
     invisibleReplySpy.mockClear();
-    dbGetActiveLeagueSeasonSpy.mockClear();
     getPlayerOverstatSpy.mockClear();
-    googleSheetsSpy.mockClear();
+    signupSpy.mockClear();
   });
 
   it("Should complete signup", async () => {
@@ -201,45 +138,39 @@ describe("Sign up", () => {
     jest.useFakeTimers();
     jest.setSystemTime(date);
     await command.run(basicInteraction);
-    expect(googleSheetsRequestSpy).toHaveBeenCalledWith({
-      auth: undefined,
-      range: "tab_name!A1",
-      requestBody: {
-        values: [
-          [
-            date.toISOString(),
-            "team name",
-            "Mondays",
-            "2 days a week, 2 years, EEC",
-            "2 returning players",
-            player1.displayName,
-            player1.id,
-            overstats.player1,
-            "Division1",
-            "Bronze",
-            "pc",
-            "No elo on record",
-            player2.displayName,
-            player2.id,
-            overstats.player2,
-            "Division2",
-            "Silver",
-            "playstation",
-            "No elo on record",
-            player3.displayName,
-            player3.id,
-            "No overstat",
-            "None",
-            "Gold",
-            "xbox",
-            "No elo on record",
-            "Additional comments provided by the user",
-          ],
-        ],
+    expect(signupSpy).toHaveBeenCalledWith(
+      "team name",
+      "Mondays",
+      "2 days a week, 2 years, EEC",
+      {
+        elo: undefined,
+        platform: platforms.player1,
+        name: player1.displayName,
+        discordId: player1.id,
+        rank: ranks.player1,
+        overstatLink: overstats.player1,
+        previous_season_vesa_division: divisions.player1,
       },
-      spreadsheetId: "google_sheet_id",
-      valueInputOption: "USER_ENTERED",
-    });
+      {
+        elo: undefined,
+        platform: platforms.player2,
+        name: player2.displayName,
+        discordId: player2.id,
+        rank: ranks.player2,
+        overstatLink: overstats.player2,
+        previous_season_vesa_division: divisions.player2,
+      },
+      {
+        elo: undefined,
+        platform: platforms.player3,
+        name: player3.displayName,
+        discordId: player3.id,
+        rank: ranks.player3,
+        overstatLink: undefined,
+        previous_season_vesa_division: divisions.player3,
+      },
+      "Additional comments provided by the user",
+    );
     expect(followUpSpy).toHaveBeenCalledWith(
       `__team name__\nSigned up by: <@player1id>.\nPlayers: <@player1id>, <@player2id>, <@player3id>.\nSignup #0. Your priority based on returning players will be determined by admins manually`,
     );
@@ -263,45 +194,39 @@ describe("Sign up", () => {
     jest.useFakeTimers();
     jest.setSystemTime(date);
     await command.run(basicInteraction);
-    expect(googleSheetsRequestSpy).toHaveBeenCalledWith({
-      auth: undefined,
-      range: "tab_name!A1",
-      requestBody: {
-        values: [
-          [
-            date.toISOString(),
-            "team name",
-            "Mondays",
-            "2 days a week, 2 years, EEC",
-            "2 returning players",
-            player1.displayName,
-            player1.id,
-            overstats.player1,
-            "Division1",
-            "Bronze",
-            "pc",
-            "No elo on record",
-            player2.displayName,
-            player2.id,
-            overstats.player2,
-            "Division2",
-            "Silver",
-            "playstation",
-            "No elo on record",
-            player3.displayName,
-            player3.id,
-            "overstat from db",
-            "None",
-            "Gold",
-            "xbox",
-            "No elo on record",
-            "Additional comments provided by the user",
-          ],
-        ],
+    expect(signupSpy).toHaveBeenCalledWith(
+      "team name",
+      "Mondays",
+      "2 days a week, 2 years, EEC",
+      {
+        elo: undefined,
+        platform: platforms.player1,
+        name: player1.displayName,
+        discordId: player1.id,
+        rank: ranks.player1,
+        overstatLink: overstats.player1,
+        previous_season_vesa_division: divisions.player1,
       },
-      spreadsheetId: "google_sheet_id",
-      valueInputOption: "USER_ENTERED",
-    });
+      {
+        elo: undefined,
+        platform: platforms.player2,
+        name: player2.displayName,
+        discordId: player2.id,
+        rank: ranks.player2,
+        overstatLink: overstats.player2,
+        previous_season_vesa_division: divisions.player2,
+      },
+      {
+        elo: undefined,
+        platform: platforms.player3,
+        name: player3.displayName,
+        discordId: player3.id,
+        rank: ranks.player3,
+        overstatLink: "overstat from db",
+        previous_season_vesa_division: divisions.player3,
+      },
+      "Additional comments provided by the user",
+    );
     expect(followUpSpy).toHaveBeenCalledWith(
       `__team name__\nSigned up by: <@player1id>.\nPlayers: <@player1id>, <@player2id>, <@player3id>.\nSignup #0. Your priority based on returning players will be determined by admins manually`,
     );
@@ -309,29 +234,11 @@ describe("Sign up", () => {
   });
 
   it("Should complete signup but warn that response can't be parsed", async () => {
-    const localGoogleValueMethods = {
-      append: (
-        request: Params$Resource$Spreadsheets$Values$Append,
-      ): Promise<GaxiosResponseWithHTTP2<Readable>> =>
-        Promise.resolve({
-          data: {
-            updates: {
-              updatedRange: "weird unparseable string",
-            },
-            request: "Request data " + request.key,
-          },
-        } as GaxiosResponseWithHTTP2),
-    };
-    googleSheetsSpy.mockReturnValueOnce({
-      spreadsheets: {
-        values: localGoogleValueMethods,
-      } as unknown as Resource$Spreadsheets,
-    } as Sheets);
-    const localGoogleRequestSpy = jest.spyOn(localGoogleValueMethods, "append");
+    signupSpy.mockResolvedValueOnce(null);
 
     await command.run(basicInteraction);
-    // re initialize request spy to spy on the local append method
-    expect(localGoogleRequestSpy).toHaveBeenCalled();
+
+    expect(signupSpy).toHaveBeenCalled();
     expect(followUpSpy).toHaveBeenCalledWith(
       `Problem parsing google sheets response, please check sheet to see if your signup went through before resubmitting`,
     );
@@ -354,9 +261,7 @@ describe("Sign up", () => {
     });
 
     it("should not complete the signup because google did a bad", async () => {
-      googleSheetsRequestSpy.mockImplementationOnce(async () => {
-        throw Error("Sheets Failure");
-      });
+      signupSpy.mockRejectedValueOnce(new Error("Sheets Failure"));
       await command.run(basicInteraction);
       expect(followUpSpy).toHaveBeenCalledWith(
         "Team not signed up. Error: Sheets Failure",
@@ -376,7 +281,9 @@ describe("Sign up", () => {
     });
 
     it("should not complete the signup because the no active league season", async () => {
-      dbGetActiveLeagueSeasonSpy.mockReturnValueOnce(Promise.resolve(null));
+      signupSpy.mockRejectedValueOnce(
+        new Error("No season found with active signups."),
+      );
       await command.run(basicInteraction);
       expect(followUpSpy).toHaveBeenCalledWith(
         `Team not signed up. Error: No season found with active signups.`,
@@ -432,7 +339,7 @@ describe("Sign up", () => {
   const getPlayerRank = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new LeagueSignupService(new DbMock()),
+      new LeagueServiceMock() as unknown as LeagueService,
     );
     if (
       key ===
@@ -459,7 +366,7 @@ describe("Sign up", () => {
   const getPlayerDivision = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new LeagueSignupService(new DbMock()),
+      new LeagueServiceMock() as unknown as LeagueService,
     );
     if (
       key ===
@@ -489,7 +396,7 @@ describe("Sign up", () => {
   const getPlayerOverstat = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new LeagueSignupService(new DbMock()),
+      new LeagueServiceMock() as unknown as LeagueService,
     );
     if (
       key ===
@@ -519,7 +426,7 @@ describe("Sign up", () => {
   const getPlayerPlatform = (key: string) => {
     const staticCommandUsedJustForInputNames = new LeagueSignupCommand(
       mockOverstatService,
-      new LeagueSignupService(new DbMock()),
+      new LeagueServiceMock() as unknown as LeagueService,
     );
     if (
       key ===

--- a/test/mocks/league.mock.ts
+++ b/test/mocks/league.mock.ts
@@ -1,0 +1,18 @@
+import { SheetsPlayer } from "../../src/services/league-signup";
+
+export class LeagueServiceMock {
+  constructor() {}
+
+  async signup(
+    teamName: string,
+    teamNoDays: string,
+    teamCompKnowledge: string,
+    player1: SheetsPlayer,
+    player2: SheetsPlayer,
+    player3: SheetsPlayer,
+    additionalComments: string,
+  ): Promise<number | null> {
+    console.debug("Mock league service signup called", teamName);
+    return Promise.resolve(1);
+  }
+}

--- a/test/mocks/league.mock.ts
+++ b/test/mocks/league.mock.ts
@@ -1,4 +1,4 @@
-import { SheetsPlayer } from "../../src/services/league-signup";
+import { SheetsPlayer, SignupResult } from "../../src/services/league-signup";
 
 export class LeagueServiceMock {
   constructor() {}
@@ -11,8 +11,14 @@ export class LeagueServiceMock {
     player2: SheetsPlayer,
     player3: SheetsPlayer,
     additionalComments: string,
-  ): Promise<number | null> {
+  ): Promise<SignupResult | null> {
     console.debug("Mock league service signup called", teamName);
-    return Promise.resolve(1);
+    return Promise.resolve({
+      rowNumber: 1,
+      seasonInfo: {
+        signupPrioEndDate: new Date("2025-12-25T00:00:00Z").toISOString(),
+        startDate: new Date("2026-01-01T00:00:00Z").toISOString(),
+      },
+    });
   }
 }

--- a/test/services/league-signup.test.ts
+++ b/test/services/league-signup.test.ts
@@ -1,0 +1,231 @@
+import {
+  LeagueService,
+  SheetsPlayer,
+  PlayerRank,
+  Platform,
+  VesaDivision,
+} from "../../src/services/league-signup";
+import * as GoogleSheets from "@googleapis/sheets";
+import { GaxiosResponseWithHTTP2, GoogleAuth } from "googleapis-common";
+import { Readable } from "stream";
+import { DbMock } from "../mocks/db.mock";
+import SpyInstance = jest.SpyInstance;
+import Resource$Spreadsheets = GoogleSheets.sheets_v4.Resource$Spreadsheets;
+import Sheets = GoogleSheets.sheets_v4.Sheets;
+import Params$Resource$Spreadsheets$Values$Append = GoogleSheets.sheets_v4.Params$Resource$Spreadsheets$Values$Append;
+
+class MockGoogleAuth {
+  getClient() {
+    return undefined;
+  }
+}
+
+describe("League Service", () => {
+  let googleSheetsRequestSpy: SpyInstance<
+    Promise<GaxiosResponseWithHTTP2<Readable>>,
+    [request: Params$Resource$Spreadsheets$Values$Append],
+    string
+  >;
+  let googleSheetsSpy: SpyInstance;
+  let dbGetActiveLeagueSeasonSpy: SpyInstance;
+  let mockDb: DbMock;
+  let leagueService: LeagueService;
+
+  const player1: SheetsPlayer = {
+    name: "Player 1",
+    discordId: "player1id",
+    elo: undefined,
+    rank: PlayerRank.Bronze,
+    previous_season_vesa_division: VesaDivision.Division1,
+    platform: Platform.pc,
+    overstatLink: "https://overstat.gg/1",
+  };
+
+  const player2: SheetsPlayer = {
+    name: "Player 2",
+    discordId: "player2id",
+    elo: undefined,
+    rank: PlayerRank.Silver,
+    previous_season_vesa_division: VesaDivision.Division2,
+    platform: Platform.playstation,
+    overstatLink: "https://overstat.gg/2",
+  };
+
+  const player3: SheetsPlayer = {
+    name: "Player 3",
+    discordId: "player3id",
+    elo: undefined,
+    rank: PlayerRank.Gold,
+    previous_season_vesa_division: VesaDivision.None,
+    platform: Platform.xbox,
+    overstatLink: undefined,
+  };
+
+  beforeAll(() => {
+    mockDb = new DbMock();
+    leagueService = new LeagueService(mockDb);
+
+    const googleValuesMethods = {
+      append: (
+        request: Params$Resource$Spreadsheets$Values$Append,
+      ): Promise<GaxiosResponseWithHTTP2<Readable>> =>
+        Promise.resolve({
+          data: {
+            updates: {
+              updatedRange: "'Discord Submittals'!A1:Y1",
+            },
+            request: "Request data " + request.key,
+          },
+        } as GaxiosResponseWithHTTP2),
+    };
+    googleSheetsRequestSpy = jest.spyOn(googleValuesMethods, "append");
+    googleSheetsSpy = jest.spyOn(GoogleSheets, "sheets").mockReturnValue({
+      spreadsheets: {
+        values: googleValuesMethods,
+      } as unknown as Resource$Spreadsheets,
+    } as Sheets);
+    jest
+      .spyOn(GoogleSheets.auth, "GoogleAuth")
+      .mockReturnValue(new MockGoogleAuth() as unknown as GoogleAuth);
+
+    dbGetActiveLeagueSeasonSpy = jest.spyOn(mockDb, "getActiveLeagueSeason");
+    dbGetActiveLeagueSeasonSpy.mockReturnValue(
+      Promise.resolve({
+        id: "1",
+        googleSheetId: "google_sheet_id",
+        googleSheetName: "tab_name",
+        googleSheetRangeStart: "A1",
+      }),
+    );
+  });
+
+  beforeEach(() => {
+    googleSheetsRequestSpy.mockClear();
+    dbGetActiveLeagueSeasonSpy.mockClear();
+    googleSheetsSpy.mockClear();
+  });
+
+  it("Should correctly parse and post spreadsheet value", async () => {
+    const date = new Date("2025-12-26T18:55:23.264Z");
+    jest.useFakeTimers();
+    jest.setSystemTime(date);
+
+    const result = await leagueService.signup(
+      "team name",
+      "Mondays",
+      "2 days a week, 2 years, EEC",
+      player1,
+      player2,
+      player3,
+      "Additional comments provided by the user",
+    );
+
+    expect(result).toBe(0); // Assuming the row number mock returns 1 - 1 = 0
+    expect(googleSheetsRequestSpy).toHaveBeenCalledWith({
+      auth: undefined,
+      range: "tab_name!A1",
+      requestBody: {
+        values: [
+          [
+            date.toISOString(),
+            "team name",
+            "Mondays",
+            "2 days a week, 2 years, EEC",
+            "2 returning players",
+            player1.name,
+            player1.discordId,
+            player1.overstatLink,
+            "Division1",
+            "Bronze",
+            "pc",
+            "No elo on record",
+            player2.name,
+            player2.discordId,
+            player2.overstatLink,
+            "Division2",
+            "Silver",
+            "playstation",
+            "No elo on record",
+            player3.name,
+            player3.discordId,
+            "No overstat",
+            "None",
+            "Gold",
+            "xbox",
+            "No elo on record",
+            "Additional comments provided by the user",
+          ],
+        ],
+      },
+      spreadsheetId: "google_sheet_id",
+      valueInputOption: "USER_ENTERED",
+    });
+
+    jest.useRealTimers();
+  });
+
+  it("Should throw error if google did a bad", async () => {
+    googleSheetsRequestSpy.mockImplementationOnce(async () => {
+      throw Error("Sheets Failure");
+    });
+
+    await expect(
+      leagueService.signup(
+        "team name",
+        "Mondays",
+        "2 days a week, 2 years, EEC",
+        player1,
+        player2,
+        player3,
+        "Additional comments provided by the user",
+      ),
+    ).rejects.toThrow("Sheets Failure");
+  });
+
+  it("Should throw error if no active league season", async () => {
+    dbGetActiveLeagueSeasonSpy.mockReturnValueOnce(Promise.resolve(null));
+    await expect(
+      leagueService.signup(
+        "team name",
+        "Mondays",
+        "2 days a week, 2 years, EEC",
+        player1,
+        player2,
+        player3,
+        "Additional comments provided by the user",
+      ),
+    ).rejects.toThrow("No season found with active signups.");
+  });
+
+  it("Should return null if response can't be parsed", async () => {
+    const localGoogleValueMethods = {
+      append: (
+        request: Params$Resource$Spreadsheets$Values$Append,
+      ): Promise<GaxiosResponseWithHTTP2<Readable>> =>
+        Promise.resolve({
+          data: {
+            updates: {
+              updatedRange: "weird unparseable string",
+            },
+            request: "Request data " + request.key,
+          },
+        } as GaxiosResponseWithHTTP2),
+    };
+    googleSheetsSpy.mockReturnValueOnce({
+      spreadsheets: {
+        values: localGoogleValueMethods,
+      } as unknown as Resource$Spreadsheets,
+    } as Sheets);
+
+    const result = await leagueService.signup(
+      "team name",
+      "Mondays",
+      "2 days a week, 2 years, EEC",
+      player1,
+      player2,
+      player3,
+      "Additional comments provided by the user",
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/test/services/league-signup.test.ts
+++ b/test/services/league-signup.test.ts
@@ -95,6 +95,8 @@ describe("League Service", () => {
         googleSheetId: "google_sheet_id",
         googleSheetName: "tab_name",
         googleSheetRangeStart: "A1",
+        signupPrioEndDate: "2025-12-25T00:00:00Z",
+        startDate: "2026-01-01T00:00:00Z",
       }),
     );
   });
@@ -120,7 +122,7 @@ describe("League Service", () => {
       "Additional comments provided by the user",
     );
 
-    expect(result).toBe(0); // Assuming the row number mock returns 1 - 1 = 0
+    expect(result?.rowNumber).toBe(0); // Assuming the row number mock returns 1 - 1 = 0
     expect(googleSheetsRequestSpy).toHaveBeenCalledWith({
       auth: undefined,
       range: "tab_name!A1",


### PR DESCRIPTION
* Allow signups to be managed from the db
  * Instead of hardcoded sheets data this data now comes from the db
  * signups have start and end dates, allowing seasons to be setup without code changes
* Lets users know if signup deadlines have passed
* Brunt of work moved out of command into new LeagueService