### PR TITLE
bugfix/compute

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrim-bot",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrim-bot",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@googleapis/sheets": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrim-bot",
   "description": "A multipurpose bot to track scrim signups, low prio and player performance among other things",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "author": "Jacob Heuman",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -66,16 +66,16 @@ export abstract class DB {
     discordChannelID: string,
     overstatId: string | null = null,
     overstatJson: JSON | null = null,
-    prioType: string | null = null,
+    prioType?: PrioType,
   ): Promise<string> {
     const ids = await this.post(DbTable.scrims, [
-      {
+      this.removeUndefined({
         date_time_field: dateTime,
         discord_channel: discordChannelID,
         overstat_id: overstatId,
         overstat_json: overstatJson,
         prio_type: prioType,
-      },
+      }),
     ]);
     return ids[0];
   }

--- a/src/services/scrim-service.ts
+++ b/src/services/scrim-service.ts
@@ -72,6 +72,7 @@ export class ScrimService {
     await this.computeNewScrims(newOverstatIds, {
       scrimDateTime: scrims[0].dateTime,
       discordChannelID,
+      prioType: scrims[0].prioType,
     });
 
     return { links: overstatLinks, dateTime: scrims[0].dateTime };
@@ -113,7 +114,11 @@ export class ScrimService {
 
   private async computeNewScrims(
     newOverstatIds: string[],
-    scrimInfo: { discordChannelID: string; scrimDateTime: Date },
+    scrimInfo: {
+      discordChannelID: string;
+      scrimDateTime: Date;
+      prioType: PrioType;
+    },
   ) {
     const errors: string[] = [];
     for (const overstatId of newOverstatIds) {
@@ -123,6 +128,7 @@ export class ScrimService {
         scrimInfo.discordChannelID,
         overstatId,
         stats,
+        scrimInfo.prioType,
       );
       try {
         await this.huggingFaceService.uploadOverstatJson(

--- a/src/services/scrim-service.ts
+++ b/src/services/scrim-service.ts
@@ -13,7 +13,7 @@ export class ScrimService {
   async createScrim(
     discordChannelID: string,
     dateTime: Date,
-    prioType: PrioType | null = null,
+    prioType?: PrioType,
   ): Promise<string> {
     const scrimId = await this.db.createNewScrim(
       dateTime,

--- a/test/services/scrim-service.test.ts
+++ b/test/services/scrim-service.test.ts
@@ -288,8 +288,8 @@ describe("ScrimService", () => {
       expect(updateScrimSpy).toHaveBeenCalledTimes(1);
 
       expect(createNewScrimSpy.mock.calls).toEqual([
-        [time, channelId, lobby2OverstatId, tournamentStats],
-        [time, channelId, lobby3OverstatId, tournamentStats],
+        [time, channelId, lobby2OverstatId, tournamentStats, PrioType.regular],
+        [time, channelId, lobby3OverstatId, tournamentStats, PrioType.regular],
       ]);
       expect(createNewScrimSpy).toHaveBeenCalledTimes(2);
       expect(huggingFaceUploadSpy.mock.calls).toEqual([
@@ -344,6 +344,7 @@ describe("ScrimService", () => {
         channelId,
         newLobbyOverstatId,
         tournamentStats,
+        PrioType.regular,
       );
     });
 

--- a/test/services/scrim-service.test.ts
+++ b/test/services/scrim-service.test.ts
@@ -101,7 +101,7 @@ describe("ScrimService", () => {
         channelId,
         null,
         null,
-        null,
+        undefined,
       );
     });
   });


### PR DESCRIPTION
* Sending null hardcoded for the prio type caused type mismatch with the db:
  * `Scrim not computed. Error: Graph ql error: unexpected null value for type 'String' `
  * Fixed this by removing the ability to send null to the db methods
* When computing multiple lobbies for same scrim the newly created scrim db entry will have same prio type as original scrim