### PR TITLE
feature/league-sort

### DIFF
--- a/docs/league-data-repository-refactor.md
+++ b/docs/league-data-repository-refactor.md
@@ -1,0 +1,157 @@
+# League Data Repository Refactor
+
+## Goal
+
+Decouple `LeagueService` from Google Sheets so that switching to Nhost as the data source touches one file: `services/index.ts`. A parallel-run phase will let both sources be validated side-by-side for at least one full season before cutting over.
+
+## Motivation
+
+`LeagueService` currently calls the Sheets API directly for reads (roster lookup) and writes (signups, sub requests, roster changes). When the league data moves to Nhost, every Sheets call needs to be replaced. Without an abstraction boundary the changes spread across `LeagueService`, its tests, and any callers.
+
+---
+
+## Interface
+
+Define `LeagueDataRepository` in `src/repositories/league-data.repository.ts`:
+
+```typescript
+export interface SignupData {
+  teamName: string;
+  teamNoDays: string;
+  teamCompKnowledge: string;
+  player1: SheetsPlayer;
+  player2: SheetsPlayer;
+  player3: SheetsPlayer;
+  additionalComments: string;
+}
+
+export interface SignupResult {
+  rowNumber: number | null;
+  seasonInfo: {
+    signupPrioEndDate: string;
+    startDate: string;
+  };
+}
+
+export interface SubRequestData {
+  teamDivision: string;
+  teamName: string;
+  weekNumber: string;
+  playerOut: LeaguePlayer;
+  playerIn: LeaguePlayer;
+  playerInDivision: string;
+  commandUser: GuildMember;
+  additionalComments: string;
+}
+
+export interface RosterChangeData {
+  teamDivision: string;
+  teamName: string;
+  playerOut: LeaguePlayer;
+  playerIn: LeaguePlayer;
+  commandUser: GuildMember;
+  additionalComments: string;
+}
+
+export interface WriteResult {
+  rowNumber: number | null;
+  url: string;
+  tabName: string;
+}
+
+export interface LeagueDataRepository {
+  getRosterDiscordIds(): Promise<Map<string, string>>;
+  writeSignup(data: SignupData): Promise<SignupResult | null>;
+  writeSubRequest(data: SubRequestData): Promise<WriteResult>;
+  writeRosterChange(data: RosterChangeData): Promise<WriteResult>;
+}
+```
+
+`LeagueService` takes `LeagueDataRepository` as a constructor parameter and delegates all data operations to it. Its own methods become thin orchestration — validate inputs, call the repository, format the Discord response.
+
+---
+
+## Implementations
+
+### `LeagueSheetRepository` (current behavior, moved)
+
+Location: `src/repositories/league-sheet.repository.ts`
+
+Contains everything currently in `LeagueService` that touches the Sheets API:
+- `getAuthClient()`
+- All `sheets({ version: "v4" })` calls
+- `SheetHelper` usage for building requests and parsing row numbers
+
+`SheetHelper` stays as-is — a low-level static utility used by this class.
+
+### `LeagueDbRepository` (future)
+
+Location: `src/repositories/league-db.repository.ts`
+
+Reads roster data from Nhost tables instead of fetching sheet tabs. Writes signup/sub/roster-change records to Nhost instead of appending sheet rows. Returns `url: ""` and `rowNumber: null` for write results, or a Nhost record ID — to be decided when the DB schema is defined.
+
+---
+
+## Parallel-Run Phase
+
+Before cutting over fully, run both repositories simultaneously for one season to confirm the Nhost data matches what was submitted via Sheets.
+
+### How to wire it
+
+In `services/index.ts`, instantiate both repositories and pass them to a thin `ParallelLeagueRepository` wrapper:
+
+```typescript
+// src/repositories/parallel-league.repository.ts
+export class ParallelLeagueRepository implements LeagueDataRepository {
+  constructor(
+    private primary: LeagueDataRepository,   // sheets — source of truth for responses
+    private shadow: LeagueDataRepository,    // nhost — writes in parallel, errors logged not thrown
+  ) {}
+
+  async writeSignup(data: SignupData): Promise<SignupResult | null> {
+    const [result] = await Promise.allSettled([
+      this.primary.writeSignup(data),
+      this.shadow.writeSignup(data).catch((e) =>
+        console.error("Shadow writeSignup failed", e),
+      ),
+    ]);
+    if (result.status === "rejected") throw result.reason;
+    return result.value;
+  }
+
+  // same pattern for writeSubRequest, writeRosterChange
+
+  async getRosterDiscordIds(): Promise<Map<string, string>> {
+    // once nhost has roster data, compare here and log divergence
+    return this.primary.getRosterDiscordIds();
+  }
+}
+```
+
+The shadow repository's failures are logged but never surface to the user. Once a season of data confirms correctness, swap `primary` and `shadow`, run for another week, then drop the parallel wrapper entirely.
+
+---
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `src/repositories/league-data.repository.ts` | New — interface and data types |
+| `src/repositories/league-sheet.repository.ts` | New — current `LeagueService` Sheets logic moved here |
+| `src/repositories/league-db.repository.ts` | New — Nhost implementation (future season) |
+| `src/repositories/parallel-league.repository.ts` | New — parallel-run wrapper (parallel-run season) |
+| `src/services/league.ts` | Remove Sheets logic, accept `LeagueDataRepository` in constructor |
+| `src/services/index.ts` | Swap which repository is wired in — the only file that changes at cutover |
+| `test/mocks/league-data.repository.mock.ts` | New — replaces current `LeagueServiceMock` for repository-level tests |
+| `test/services/league.test.ts` | Test `LeagueService` against a mock repository; move Sheets-specific tests to `league-sheet.repository.test.ts` |
+
+`SignupService`, `RosterService`, commands, and everything else that depends on `LeagueService` — no changes.
+
+---
+
+## Cutover Sequence
+
+1. **Now**: merge this refactor, `LeagueSheetRepository` wired as the sole implementation — behavior identical to today.
+2. **Next season**: build `LeagueDbRepository` + `ParallelLeagueRepository`. Wire parallel mode. Monitor logs for divergence.
+3. **Season after** (or mid-season once confident): flip `primary`/`shadow`. Sheets becomes the shadow, Nhost drives responses.
+4. **Final cleanup**: remove `ParallelLeagueRepository` and `LeagueSheetRepository` once Sheets is confirmed retired.

--- a/nhost/nhost/migrations/default/1778263220374_alter_table_public_league_seasons/down.sql
+++ b/nhost/nhost/migrations/default/1778263220374_alter_table_public_league_seasons/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.league_seasons DROP CONSTRAINT IF EXISTS league_seasons_roster_sheet_id_fkey;
+ALTER TABLE public.league_seasons DROP COLUMN IF EXISTS roster_sheet_id;

--- a/nhost/nhost/migrations/default/1778263220374_alter_table_public_league_seasons/up.sql
+++ b/nhost/nhost/migrations/default/1778263220374_alter_table_public_league_seasons/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.league_seasons ADD roster_sheet_id uuid;
+ALTER TABLE public.league_seasons ADD CONSTRAINT league_seasons_roster_sheet_id_fkey FOREIGN KEY (roster_sheet_id) REFERENCES public.google_sheets (id) ON UPDATE RESTRICT ON DELETE RESTRICT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrim-bot",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrim-bot",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@googleapis/sheets": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrim-bot",
   "description": "A multipurpose bot to track scrim signups, low prio and player performance among other things",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "author": "Jacob Heuman",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/commands/scrims/admin/scrim-crud/get-signups.ts
+++ b/src/commands/scrims/admin/scrim-crud/get-signups.ts
@@ -175,12 +175,6 @@ export class GetSignupsCommand extends AdminCommand {
       this.resolveTeamMmr(team, mmrMap),
     );
     teamsWithMmr.sort((a, b) => {
-      const prioResult =
-        (b.team.prio?.amount ?? 0) - (a.team.prio?.amount ?? 0);
-      if (prioResult !== 0) {
-        return prioResult;
-      }
-      // missing MMR teams float to top within their priority tier
       if (a.missingMmr !== b.missingMmr) {
         return a.missingMmr ? -1 : 1;
       }

--- a/src/commands/scrims/admin/scrim-crud/get-signups.ts
+++ b/src/commands/scrims/admin/scrim-crud/get-signups.ts
@@ -142,7 +142,8 @@ export class GetSignupsCommand extends AdminCommand {
       const playerColumns = team.players.map((p) =>
         this.getPlayerCsvFields(p, mmrMap),
       );
-      return [teamNameColumn, ...playerColumns].join(",");
+      const prioColumn = `"${team.prio?.amount ?? 0}: ${team.prio?.reasons ?? ""}"`;
+      return [teamNameColumn, ...playerColumns, prioColumn].join(",");
     };
     const mainListString = mainList.map(teamCsvStringConverter).join("\n");
     const sampleTeam = mainList[0] ?? waitList[0];
@@ -167,7 +168,8 @@ export class GetSignupsCommand extends AdminCommand {
       "missing_mmr_flag,team_name,team_mmr,team_discord_pings," +
       "player1_name,player1_overstat_url,player1_mmr," +
       "player2_name,player2_overstat_url,player2_mmr," +
-      "player3_name,player3_overstat_url,player3_mmr";
+      "player3_name,player3_overstat_url,player3_mmr," +
+      "prio";
 
     const teamsWithMmr = mainList.map((team) =>
       this.resolveTeamMmr(team, mmrMap),
@@ -207,8 +209,11 @@ export class GetSignupsCommand extends AdminCommand {
           playerMmrs[i] !== undefined ? playerMmrs[i]!.toFixed(3) : "n/a";
         return `${p.displayName},${overstatUrl},${mmr}`;
       });
+      const prioCol = `"${team.prio?.amount ?? 0}: ${team.prio?.reasons ?? ""}"`;
       rows.push(
-        [flag, team.teamName, mmrDisplay, pings, ...playerCols].join(","),
+        [flag, team.teamName, mmrDisplay, pings, ...playerCols, prioCol].join(
+          ",",
+        ),
       );
     });
 

--- a/src/commands/scrims/signup/current-position.ts
+++ b/src/commands/scrims/signup/current-position.ts
@@ -40,7 +40,7 @@ export class CurrentPositionCommand extends MemberCommand {
       );
     }
     const prioActive =
-      (scrim?.scrimType ?? ScrimType.regular) === ScrimType.regular;
+      (scrim?.scrimType ?? ScrimType.regular) !== ScrimType.tournament;
 
     const { mainList, waitList } = channelSignups;
     const list: ScrimSignup[] = [...mainList, ...waitList];
@@ -81,7 +81,7 @@ export class CurrentPositionCommand extends MemberCommand {
     if (replyArray.length === 0) {
       await interaction.editReply("Member not found on any team in this scrim");
     } else {
-      if (prioActive) {
+      if (prioActive && scrim?.scrimType === ScrimType.regular) {
         const qualifier = userTeamHasPrio ? "other " : "";
         const positiveIsPlural = teamsWithPrio.positive !== 1;
         const negativeIsPlural = teamsWithPrio.negative !== 1;

--- a/src/commands/scrims/signup/current-position.ts
+++ b/src/commands/scrims/signup/current-position.ts
@@ -69,7 +69,7 @@ export class CurrentPositionCommand extends MemberCommand {
         if (prioActive && (signup.prio?.amount ?? 0) !== 0) {
           userTeamHasPrio = true;
         }
-      } else if (prioActive) {
+      } else if (prioActive && scrim?.scrimType === ScrimType.regular) {
         if ((signup.prio?.amount ?? 0) < 0) {
           teamsWithPrio.negative++;
         } else if ((signup.prio?.amount ?? 0) > 0) {

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -416,6 +416,7 @@ export abstract class DB {
     signupSheet: GoogleSheetConfig;
     subSheet: GoogleSheetConfig;
     rosterChangeSheet: GoogleSheetConfig;
+    rosterSheet: GoogleSheetConfig | null;
     signupPrioEndDate: string;
     startDate: string;
   } | null> {
@@ -443,6 +444,7 @@ export abstract class DB {
         { signup_sheet: ["sheet_id", "tab_name", "range_start"] },
         { sub_sheet: ["sheet_id", "tab_name", "range_start"] },
         { roster_change_sheet: ["sheet_id", "tab_name", "range_start"] },
+        { roster_sheet: ["sheet_id", "tab_name", "range_start"] },
       ],
     );
 
@@ -467,6 +469,13 @@ export abstract class DB {
           tabName: row.roster_change_sheet.tab_name as string,
           rangeStart: row.roster_change_sheet.range_start as string,
         },
+        rosterSheet: row.roster_sheet
+          ? {
+              spreadsheetId: row.roster_sheet.sheet_id as string,
+              tabName: row.roster_sheet.tab_name as string,
+              rangeStart: row.roster_sheet.range_start as string,
+            }
+          : null,
       };
     } else {
       return null;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -21,7 +21,6 @@ export const staticValueService = new StaticValueService(nhostDb);
 export const discordService = new DiscordService(client, staticValueService);
 
 export const authService = new AuthService(nhostDb);
-export const prioService = new PrioService(nhostDb);
 export const banService = new BanService(nhostDb);
 export const scrimService = new ScrimService(
   nhostDb,
@@ -29,6 +28,7 @@ export const scrimService = new ScrimService(
   huggingFaceService,
 );
 export const leagueService = new LeagueService(nhostDb);
+export const prioService = new PrioService(nhostDb, leagueService);
 export const signupsService = new SignupService(
   nhostDb,
   prioService,
@@ -36,7 +36,6 @@ export const signupsService = new SignupService(
   discordService,
   banService,
   scrimService,
-  leagueService,
 );
 export const rosterService = new RosterService(
   nhostDb,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -28,6 +28,7 @@ export const scrimService = new ScrimService(
   overstatService,
   huggingFaceService,
 );
+export const leagueService = new LeagueService(nhostDb);
 export const signupsService = new SignupService(
   nhostDb,
   prioService,
@@ -35,6 +36,7 @@ export const signupsService = new SignupService(
   discordService,
   banService,
   scrimService,
+  leagueService,
 );
 export const rosterService = new RosterService(
   nhostDb,
@@ -45,5 +47,4 @@ export const rosterService = new RosterService(
   scrimService,
   signupsService,
 );
-export const leagueService = new LeagueService(nhostDb);
 export const mmrService = new MmrService(nhostDb);

--- a/src/services/league.ts
+++ b/src/services/league.ts
@@ -218,7 +218,6 @@ export class LeagueService {
       for (const row of response.data.values ?? []) {
         const teamName = row[0];
         if (!teamName) continue;
-        // cols 3, 6, 9 are P1 ID, P2 ID, P3 ID
         const p1Id = row[3];
         const p2Id = row[6];
         const p3Id = row[9];

--- a/src/services/league.ts
+++ b/src/services/league.ts
@@ -186,6 +186,51 @@ export class LeagueService {
     };
   }
 
+  async getRosterDiscordIds(): Promise<Map<string, string>> {
+    const activeSeason = await this.db.getActiveLeagueSeason();
+    if (!activeSeason?.rosterSheet) {
+      return new Map();
+    }
+
+    const { spreadsheetId } = activeSeason.rosterSheet;
+    const authClient = await this.getAuthClient();
+    const sheetsClient = sheets({ version: "v4" });
+
+    const metadata = await sheetsClient.spreadsheets.get({
+      spreadsheetId,
+      auth: authClient as OAuth2Client,
+      fields: "sheets.properties.title",
+    });
+
+    const divTabs = (metadata.data.sheets ?? [])
+      .map((s) => s.properties?.title)
+      .filter((title): title is string => !!title && /^DIV \d+$/.test(title));
+
+    const rosterMap = new Map<string, string>();
+
+    for (const tab of divTabs) {
+      const response = await sheetsClient.spreadsheets.values.get({
+        spreadsheetId,
+        range: `${tab}!A2:J`,
+        auth: authClient as OAuth2Client,
+      });
+
+      for (const row of response.data.values ?? []) {
+        const teamName = row[0];
+        if (!teamName) continue;
+        // cols 3, 6, 9 are P1 ID, P2 ID, P3 ID
+        const p1Id = row[3];
+        const p2Id = row[6];
+        const p3Id = row[9];
+        if (p1Id) rosterMap.set(p1Id, teamName);
+        if (p2Id) rosterMap.set(p2Id, teamName);
+        if (p3Id) rosterMap.set(p3Id, teamName);
+      }
+    }
+
+    return rosterMap;
+  }
+
   private toSheetRange(sheet: GoogleSheetConfig): {
     id: string;
     range: string;

--- a/src/services/prio.ts
+++ b/src/services/prio.ts
@@ -1,10 +1,60 @@
 import { DB } from "../db/db";
 import { User } from "discord.js";
-import { ScrimSignup } from "../models/Scrims";
+import { Scrim, ScrimSignup, ScrimType } from "../models/Scrims";
 import { ExpungedPlayerPrio, PlayerMap, PlayerPrio } from "../models/Prio";
+import { Player } from "../models/Player";
+import { LeagueService } from "./league";
+
+function getLeagueTierInfo(
+  players: Player[],
+  rosterMap: Map<string, string>,
+): { tier: number; reason: string } {
+  const teamCounts = new Map<string, number>();
+  for (const player of players) {
+    const teamName = rosterMap.get(player.discordId);
+    if (teamName) {
+      teamCounts.set(teamName, (teamCounts.get(teamName) ?? 0) + 1);
+    }
+  }
+
+  const maxSameTeam =
+    teamCounts.size > 0 ? Math.max(...teamCounts.values()) : 0;
+
+  if (maxSameTeam === 3) {
+    const teamName = [...teamCounts.keys()][0];
+    return { tier: 5, reason: `3/3 players from ${teamName}` };
+  }
+  if (maxSameTeam === 2) {
+    const dominantTeam = [...teamCounts.entries()].find(
+      ([, count]) => count === 2,
+    )![0];
+    const otherTeam = [...teamCounts.keys()].find((t) => t !== dominantTeam);
+    if (otherTeam) {
+      return {
+        tier: 4,
+        reason: `2/3 players from ${dominantTeam}, 1 from ${otherTeam}`,
+      };
+    }
+    return {
+      tier: 3,
+      reason: `2/3 players from ${dominantTeam}, 1 not in league`,
+    };
+  }
+  if (teamCounts.size === 3) {
+    const teams = [...teamCounts.keys()].join(", ");
+    return {
+      tier: 2,
+      reason: `all 3 players from different league teams: ${teams}`,
+    };
+  }
+  return { tier: 1, reason: "fewer than 2 players from same league team" };
+}
 
 export class PrioService {
-  constructor(private db: DB) {}
+  constructor(
+    private db: DB,
+    private leagueService: LeagueService,
+  ) {}
 
   async setPlayerPrio(
     prioUsers: User[],
@@ -23,10 +73,21 @@ export class PrioService {
 
   // changes teams in place and returns the teams, does NOT sort
   async getTeamPrioForScrim(
-    scrim: { dateTime: Date },
+    scrim: Scrim,
     teams: ScrimSignup[],
     discordIdsWithScrimPass: string[],
   ): Promise<ScrimSignup[]> {
+    if (scrim.scrimType === ScrimType.tournament) {
+      return teams;
+    }
+    if (scrim.scrimType === ScrimType.league) {
+      const rosterMap = await this.leagueService.getRosterDiscordIds();
+      for (const team of teams) {
+        const { tier, reason } = getLeagueTierInfo(team.players, rosterMap);
+        team.prio = { amount: tier, reasons: reason };
+      }
+      return teams;
+    }
     const playersWithPrio = await this.db.getPrio(scrim.dateTime);
     const playerMap = this.generatePlayerMap(
       playersWithPrio,

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -2,59 +2,13 @@ import { GuildMember, User } from "discord.js";
 import { Player, PlayerInsert } from "../models/Player";
 import { DB } from "../db/db";
 import { ScrimSignupsWithPlayers } from "../db/table.interfaces";
-import { ScrimType, Scrim, ScrimSignup } from "../models/Scrims";
+import { Scrim, ScrimSignup } from "../models/Scrims";
 import { PrioService } from "./prio";
 import { appConfig } from "../config";
 import { AuthService } from "./auth";
 import { DiscordService } from "./discord";
 import { BanService } from "./ban";
 import { ScrimService } from "./scrim-service";
-import { LeagueService } from "./league";
-
-function getLeagueTierReason(tier: number): string {
-  switch (tier) {
-    case 5:
-      return "3/3 players from same league team";
-    case 4:
-      return "2/3 players from same league team, 1 from different league team";
-    case 3:
-      return "2/3 players from same league team, 1 not in league";
-    case 2:
-      return "all 3 players from different league teams";
-    default:
-      return "fewer than 2 players from same league team";
-  }
-}
-
-function getLeagueTier(
-  players: Player[],
-  rosterMap: Map<string, string>,
-): number {
-  const teamCounts = new Map<string, number>();
-  for (const player of players) {
-    const teamName = rosterMap.get(player.discordId);
-    if (teamName) {
-      teamCounts.set(teamName, (teamCounts.get(teamName) ?? 0) + 1);
-    }
-  }
-
-  const maxSameTeam =
-    teamCounts.size > 0 ? Math.max(...teamCounts.values()) : 0;
-
-  if (maxSameTeam === 3) return 5;
-  if (maxSameTeam === 2) {
-    const dominantTeam = [...teamCounts.entries()].find(
-      ([, count]) => count === 2,
-    )![0];
-    const thirdPlayerInLeague = players.some((p) => {
-      const team = rosterMap.get(p.discordId);
-      return team !== undefined && team !== dominantTeam;
-    });
-    return thirdPlayerInLeague ? 4 : 3;
-  }
-  if (teamCounts.size === 3) return 2;
-  return 1;
-}
 
 export class SignupService {
   constructor(
@@ -64,7 +18,6 @@ export class SignupService {
     private discordService: DiscordService,
     private banService: BanService,
     private scrimService: ScrimService,
-    private leagueService: LeagueService,
   ) {}
 
   async addTeam(
@@ -167,47 +120,26 @@ export class SignupService {
       throw Error("No scrim found for that channel");
     }
     const teams = await this.getRawSignups(scrim);
-    // this adds prio to the teams
     await this.prioService.getTeamPrioForScrim(
       scrim,
       teams,
       discordIdsWithScrimPass ?? [],
     );
-    return this.sortTeams(teams, scrim.scrimType);
+    return this.sortTeams(teams);
   }
 
-  private async sortTeams(
-    teams: ScrimSignup[],
-    scrimType: ScrimType,
-  ): Promise<{
+  private sortTeams(teams: ScrimSignup[]): {
     mainList: ScrimSignup[];
     waitList: ScrimSignup[];
-  }> {
+  } {
     const lobbySize = appConfig.lobbySize;
     const waitlistCutoff =
       lobbySize * Math.floor(teams.length / lobbySize) || lobbySize;
-    if (scrimType === ScrimType.league) {
-      const rosterMap = await this.leagueService.getRosterDiscordIds();
-      for (const team of teams) {
-        const tier = getLeagueTier(team.players, rosterMap);
-        team.prio = { amount: tier, reasons: getLeagueTierReason(tier) };
-      }
-    }
     const sortedTeams = [...teams].sort((teamA, teamB) => {
-      if (scrimType === ScrimType.regular) {
-        const lowPrioResult =
-          (teamB.prio?.amount ?? 0) - (teamA.prio?.amount ?? 0);
-        if (lowPrioResult !== 0) {
-          return lowPrioResult;
-        }
-      } else if (scrimType === ScrimType.league) {
-        const tierResult =
-          (teamB.prio?.amount ?? 0) - (teamA.prio?.amount ?? 0);
-        if (tierResult !== 0) {
-          return tierResult;
-        }
+      const prioResult = (teamB.prio?.amount ?? 0) - (teamA.prio?.amount ?? 0);
+      if (prioResult !== 0) {
+        return prioResult;
       }
-      // lower date is better, so subtract b from a
       return teamA.date.valueOf() - teamB.date.valueOf();
     });
     return {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -87,8 +87,7 @@ export class SignupService {
       throw Error("Duplicate player");
     }
 
-    const { mainList, waitList } = await this.getSignups(discordChannelID);
-    const scrimSignups = [...mainList, ...waitList];
+    const scrimSignups = await this.getRawSignups(scrim);
     // yes this is a three deep for loop, this is a cry for help, please optimize this
     for (const team of scrimSignups) {
       if (team.teamName === teamName) {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -11,6 +11,21 @@ import { BanService } from "./ban";
 import { ScrimService } from "./scrim-service";
 import { LeagueService } from "./league";
 
+function getLeagueTierReason(tier: number): string {
+  switch (tier) {
+    case 5:
+      return "3/3 players from same league team";
+    case 4:
+      return "2/3 players from same league team, 1 from different league team";
+    case 3:
+      return "2/3 players from same league team, 1 not in league";
+    case 2:
+      return "all 3 players from different league teams";
+    default:
+      return "fewer than 2 players from same league team";
+  }
+}
+
 function getLeagueTier(
   players: Player[],
   rosterMap: Map<string, string>,
@@ -26,7 +41,7 @@ function getLeagueTier(
   const maxSameTeam =
     teamCounts.size > 0 ? Math.max(...teamCounts.values()) : 0;
 
-  if (maxSameTeam === 3) return 1;
+  if (maxSameTeam === 3) return 5;
   if (maxSameTeam === 2) {
     const dominantTeam = [...teamCounts.entries()].find(
       ([, count]) => count === 2,
@@ -35,10 +50,10 @@ function getLeagueTier(
       const team = rosterMap.get(p.discordId);
       return team !== undefined && team !== dominantTeam;
     });
-    return thirdPlayerInLeague ? 2 : 3;
+    return thirdPlayerInLeague ? 4 : 3;
   }
-  if (teamCounts.size === 3) return 4;
-  return 5;
+  if (teamCounts.size === 3) return 2;
+  return 1;
 }
 
 export class SignupService {
@@ -172,9 +187,12 @@ export class SignupService {
     const lobbySize = appConfig.lobbySize;
     const waitlistCutoff =
       lobbySize * Math.floor(teams.length / lobbySize) || lobbySize;
-    let rosterMap: Map<string, string> | undefined;
     if (scrimType === ScrimType.league) {
-      rosterMap = await this.leagueService.getRosterDiscordIds();
+      const rosterMap = await this.leagueService.getRosterDiscordIds();
+      for (const team of teams) {
+        const tier = getLeagueTier(team.players, rosterMap);
+        team.prio = { amount: tier, reasons: getLeagueTierReason(tier) };
+      }
     }
     const sortedTeams = [...teams].sort((teamA, teamB) => {
       if (scrimType === ScrimType.regular) {
@@ -183,10 +201,9 @@ export class SignupService {
         if (lowPrioResult !== 0) {
           return lowPrioResult;
         }
-      } else if (scrimType === ScrimType.league && rosterMap) {
+      } else if (scrimType === ScrimType.league) {
         const tierResult =
-          getLeagueTier(teamA.players, rosterMap) -
-          getLeagueTier(teamB.players, rosterMap);
+          (teamB.prio?.amount ?? 0) - (teamA.prio?.amount ?? 0);
         if (tierResult !== 0) {
           return tierResult;
         }

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -263,8 +263,8 @@ export class SignupService {
   }
 
   private async updateScrimSignupCount(scrim: Scrim) {
-    const { mainList, waitList } = await this.getSignups(scrim.discordChannel);
-    const count = mainList.length + waitList.length;
+    const signups = await this.getRawSignups(scrim);
+    const count = signups.length;
     try {
       await this.discordService.updateSignupPostDescription(scrim, count);
     } catch (e) {

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -9,6 +9,36 @@ import { AuthService } from "./auth";
 import { DiscordService } from "./discord";
 import { BanService } from "./ban";
 import { ScrimService } from "./scrim-service";
+import { LeagueService } from "./league";
+
+function getLeagueTier(
+  players: Player[],
+  rosterMap: Map<string, string>,
+): number {
+  const teamCounts = new Map<string, number>();
+  for (const player of players) {
+    const teamName = rosterMap.get(player.discordId);
+    if (teamName) {
+      teamCounts.set(teamName, (teamCounts.get(teamName) ?? 0) + 1);
+    }
+  }
+
+  const maxSameTeam =
+    teamCounts.size > 0 ? Math.max(...teamCounts.values()) : 0;
+
+  if (maxSameTeam === 3) return 1;
+  if (maxSameTeam === 2) {
+    const dominantTeam = [...teamCounts.entries()].find(
+      ([, count]) => count === 2,
+    )![0];
+    const thirdPlayerInLeague = players.some((p) => {
+      const team = rosterMap.get(p.discordId);
+      return team !== undefined && team !== dominantTeam;
+    });
+    return thirdPlayerInLeague ? 2 : 3;
+  }
+  return 4;
+}
 
 export class SignupService {
   constructor(
@@ -18,6 +48,7 @@ export class SignupService {
     private discordService: DiscordService,
     private banService: BanService,
     private scrimService: ScrimService,
+    private leagueService: LeagueService,
   ) {}
 
   async addTeam(
@@ -130,22 +161,33 @@ export class SignupService {
     return this.sortTeams(teams, scrim.prioType);
   }
 
-  private sortTeams(
+  private async sortTeams(
     teams: ScrimSignup[],
     prioType: PrioType,
-  ): {
+  ): Promise<{
     mainList: ScrimSignup[];
     waitList: ScrimSignup[];
-  } {
+  }> {
     const lobbySize = appConfig.lobbySize;
     const waitlistCutoff =
       lobbySize * Math.floor(teams.length / lobbySize) || lobbySize;
+    let rosterMap: Map<string, string> | undefined;
+    if (prioType === PrioType.league) {
+      rosterMap = await this.leagueService.getRosterDiscordIds();
+    }
     const sortedTeams = [...teams].sort((teamA, teamB) => {
       if (prioType === PrioType.regular) {
         const lowPrioResult =
           (teamB.prio?.amount ?? 0) - (teamA.prio?.amount ?? 0);
         if (lowPrioResult !== 0) {
           return lowPrioResult;
+        }
+      } else if (prioType === PrioType.league && rosterMap) {
+        const tierResult =
+          getLeagueTier(teamA.players, rosterMap) -
+          getLeagueTier(teamB.players, rosterMap);
+        if (tierResult !== 0) {
+          return tierResult;
         }
       }
       // lower date is better, so subtract b from a

--- a/src/services/signups.ts
+++ b/src/services/signups.ts
@@ -37,7 +37,8 @@ function getLeagueTier(
     });
     return thirdPlayerInLeague ? 2 : 3;
   }
-  return 4;
+  if (teamCounts.size === 3) return 4;
+  return 5;
 }
 
 export class SignupService {

--- a/test/mocks/league.mock.ts
+++ b/test/mocks/league.mock.ts
@@ -42,6 +42,11 @@ export class LeagueServiceMock {
     });
   }
 
+  async getRosterDiscordIds(): Promise<Map<string, string>> {
+    console.debug("Mock league service getRosterDiscordIds called");
+    return Promise.resolve(new Map());
+  }
+
   async rosterChange(
     teamDivision: string,
     teamName: string,

--- a/test/services/league.test.ts
+++ b/test/services/league.test.ts
@@ -108,6 +108,11 @@ describe("League Service", () => {
           tabName: "roster_tab_name",
           rangeStart: "A1",
         },
+        rosterSheet: {
+          spreadsheetId: "league_roster_sheet_id",
+          tabName: "unused",
+          rangeStart: "A2",
+        },
         signupPrioEndDate: "2025-12-25T00:00:00Z",
         startDate: "2026-01-01T00:00:00Z",
       }),
@@ -514,6 +519,147 @@ describe("League Service", () => {
         sheetUrl: "https://docs.google.com/spreadsheets/d/roster_sheet_id",
         tabName: "roster_tab_name",
       });
+    });
+  });
+
+  describe("getRosterDiscordIds", () => {
+    it("Should return roster map built from all DIV tabs", async () => {
+      const mockGetSpreadsheet = jest.fn().mockResolvedValue({
+        data: {
+          sheets: [
+            { properties: { title: "DIV 1" } },
+            { properties: { title: "DIV 2" } },
+            { properties: { title: "Not a div" } },
+          ],
+        },
+      });
+      const mockGetValues = jest
+        .fn()
+        .mockResolvedValueOnce({
+          data: {
+            values: [
+              [
+                "Team Alpha",
+                "captainDiscord",
+                "P1Name",
+                "alpha1",
+                "os1",
+                "P2Name",
+                "alpha2",
+                "os2",
+                "P3Name",
+                "alpha3",
+                "os3",
+              ],
+              [
+                "Team Beta",
+                "captainDiscord2",
+                "P4Name",
+                "beta1",
+                "os4",
+                "P5Name",
+                "beta2",
+                "os5",
+                "P6Name",
+                "beta3",
+                "os6",
+              ],
+            ],
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            values: [
+              [
+                "Team Gamma",
+                "captainDiscord3",
+                "P7Name",
+                "gamma1",
+                "os7",
+                "P8Name",
+                "gamma2",
+                "os8",
+                "P9Name",
+                "gamma3",
+                "os9",
+              ],
+            ],
+          },
+        });
+      googleSheetsSpy.mockReturnValueOnce({
+        spreadsheets: {
+          get: mockGetSpreadsheet,
+          values: {
+            append: googleSheetsRequestSpy,
+            get: mockGetValues,
+          },
+        } as unknown as Resource$Spreadsheets,
+      } as Sheets);
+
+      const result = await leagueService.getRosterDiscordIds();
+
+      expect(result.get("alpha1")).toBe("Team Alpha");
+      expect(result.get("alpha2")).toBe("Team Alpha");
+      expect(result.get("alpha3")).toBe("Team Alpha");
+      expect(result.get("beta1")).toBe("Team Beta");
+      expect(result.get("beta2")).toBe("Team Beta");
+      expect(result.get("beta3")).toBe("Team Beta");
+      expect(result.get("gamma1")).toBe("Team Gamma");
+      expect(result.get("gamma2")).toBe("Team Gamma");
+      expect(result.get("gamma3")).toBe("Team Gamma");
+      expect(result.size).toBe(9);
+      expect(mockGetSpreadsheet).toHaveBeenCalledWith({
+        spreadsheetId: "league_roster_sheet_id",
+        auth: undefined,
+        fields: "sheets.properties.title",
+      });
+      expect(mockGetValues).toHaveBeenCalledWith({
+        spreadsheetId: "league_roster_sheet_id",
+        range: "DIV 1!A2:J",
+        auth: undefined,
+      });
+      expect(mockGetValues).toHaveBeenCalledWith({
+        spreadsheetId: "league_roster_sheet_id",
+        range: "DIV 2!A2:J",
+        auth: undefined,
+      });
+    });
+
+    it("Should return empty map when no roster sheet configured", async () => {
+      dbGetActiveLeagueSeasonSpy.mockReturnValueOnce(
+        Promise.resolve({
+          id: "1",
+          signupSheet: {
+            spreadsheetId: "google_sheet_id",
+            tabName: "tab_name",
+            rangeStart: "A1",
+          },
+          subSheet: {
+            spreadsheetId: "sub_sheet_id",
+            tabName: "DIV 1 Log",
+            rangeStart: "A1",
+          },
+          rosterChangeSheet: {
+            spreadsheetId: "roster_sheet_id",
+            tabName: "roster_tab_name",
+            rangeStart: "A1",
+          },
+          rosterSheet: null,
+          signupPrioEndDate: "2025-12-25T00:00:00Z",
+          startDate: "2026-01-01T00:00:00Z",
+        }),
+      );
+
+      const result = await leagueService.getRosterDiscordIds();
+      expect(result.size).toBe(0);
+      expect(googleSheetsSpy).not.toHaveBeenCalled();
+    });
+
+    it("Should return empty map when no active season", async () => {
+      dbGetActiveLeagueSeasonSpy.mockReturnValueOnce(Promise.resolve(null));
+
+      const result = await leagueService.getRosterDiscordIds();
+      expect(result.size).toBe(0);
     });
   });
 });

--- a/test/services/prio.test.ts
+++ b/test/services/prio.test.ts
@@ -211,6 +211,24 @@ describe("Prio", () => {
     });
   });
 
+  describe("getTeamPrioForScrim - tournament type", () => {
+    it("should not set prio when scrim type is tournament", async () => {
+      const tournamentScrim: Scrim = {
+        scrimType: ScrimType.tournament,
+        dateTime: new Date(),
+      } as Scrim;
+      const team: ScrimSignup = {
+        date: new Date(),
+        players: [],
+        signupId: "",
+        signupPlayer: { id: "", discordId: "", displayName: "" },
+        teamName: "",
+      };
+      await prioService.getTeamPrioForScrim(tournamentScrim, [team], []);
+      expect(team.prio).toBeUndefined();
+    });
+  });
+
   describe("setTeamPrioForScrim()", () => {
     describe("correctly set prio", () => {
       beforeEach(() => {});
@@ -332,22 +350,6 @@ describe("Prio", () => {
             },
           },
         ]);
-      });
-
-      it("should not set prio when scrim type is tournament", async () => {
-        const tournamentScrim: Scrim = {
-          scrimType: ScrimType.tournament,
-          dateTime: new Date(),
-        } as Scrim;
-        const team: ScrimSignup = {
-          date: new Date(),
-          players: [],
-          signupId: "",
-          signupPlayer: { id: "", discordId: "", displayName: "" },
-          teamName: "",
-        };
-        await prioService.getTeamPrioForScrim(tournamentScrim, [team], []);
-        expect(team.prio).toBeUndefined();
       });
 
       it("should set high prio for teams from its players", async () => {

--- a/test/services/prio.test.ts
+++ b/test/services/prio.test.ts
@@ -3,11 +3,14 @@ import { Player, PlayerInsert } from "../../src/models/Player";
 import { PrioService } from "../../src/services/prio";
 import { DbMock } from "../mocks/db.mock";
 import SpyInstance = jest.SpyInstance;
-import { Scrim, ScrimSignup } from "../../src/models/Scrims";
+import { Scrim, ScrimSignup, ScrimType } from "../../src/models/Scrims";
+import { LeagueServiceMock } from "../mocks/league.mock";
+import { LeagueService } from "../../src/services/league";
 
 describe("Prio", () => {
   let prioService: PrioService;
   let dbMock: DbMock;
+  let leagueServiceMock: LeagueServiceMock;
   let dbInsertPlayerSpy: SpyInstance<
     Promise<Player[]>,
     [players: PlayerInsert[]],
@@ -30,7 +33,11 @@ describe("Prio", () => {
 
   beforeEach(() => {
     dbMock = new DbMock();
-    prioService = new PrioService(dbMock);
+    leagueServiceMock = new LeagueServiceMock();
+    prioService = new PrioService(
+      dbMock,
+      leagueServiceMock as unknown as LeagueService,
+    );
     dbInsertPlayerSpy = jest.spyOn(dbMock, "insertPlayers");
     dbInsertPlayerSpy.mockReturnValue(Promise.resolve([player]));
   });
@@ -86,6 +93,120 @@ describe("Prio", () => {
             displayName: prioUser.displayName,
           },
         ]);
+      });
+    });
+  });
+
+  describe("getTeamPrioForScrim - league type", () => {
+    const leagueScrim: Scrim = {
+      scrimType: ScrimType.league,
+      dateTime: new Date(),
+    } as Scrim;
+
+    const makePlayer = (discordId: string): Player => ({
+      discordId,
+      displayName: discordId,
+      id: discordId,
+    });
+
+    const makeTeam = (discordIds: [string, string, string]): ScrimSignup => ({
+      date: new Date(),
+      players: [
+        makePlayer(discordIds[0]),
+        makePlayer(discordIds[1]),
+        makePlayer(discordIds[2]),
+      ],
+      signupId: "",
+      signupPlayer: makePlayer(""),
+      teamName: "",
+    });
+
+    it("should assign tier 5 when all 3 on same league team", async () => {
+      jest
+        .spyOn(leagueServiceMock, "getRosterDiscordIds")
+        .mockResolvedValueOnce(
+          new Map([
+            ["alpha1", "Alpha"],
+            ["alpha2", "Alpha"],
+            ["alpha3", "Alpha"],
+          ]),
+        );
+      const team = makeTeam(["alpha1", "alpha2", "alpha3"]);
+      await prioService.getTeamPrioForScrim(leagueScrim, [team], []);
+      expect(team.prio).toEqual({
+        amount: 5,
+        reasons: "3/3 players from Alpha",
+      });
+    });
+
+    it("should assign tier 4 when 2 on same team and 1 on different league team", async () => {
+      jest
+        .spyOn(leagueServiceMock, "getRosterDiscordIds")
+        .mockResolvedValueOnce(
+          new Map([
+            ["alpha1", "Alpha"],
+            ["alpha2", "Alpha"],
+            ["beta1", "Beta"],
+          ]),
+        );
+      const team = makeTeam(["alpha1", "alpha2", "beta1"]);
+      await prioService.getTeamPrioForScrim(leagueScrim, [team], []);
+      expect(team.prio).toEqual({
+        amount: 4,
+        reasons: "2/3 players from Alpha, 1 from Beta",
+      });
+    });
+
+    it("should assign tier 3 when 2 on same team and 1 not in league", async () => {
+      jest
+        .spyOn(leagueServiceMock, "getRosterDiscordIds")
+        .mockResolvedValueOnce(
+          new Map([
+            ["alpha1", "Alpha"],
+            ["alpha2", "Alpha"],
+          ]),
+        );
+      const team = makeTeam(["alpha1", "alpha2", "outsider"]);
+      await prioService.getTeamPrioForScrim(leagueScrim, [team], []);
+      expect(team.prio).toEqual({
+        amount: 3,
+        reasons: "2/3 players from Alpha, 1 not in league",
+      });
+    });
+
+    it("should assign tier 2 when all 3 on different league teams", async () => {
+      jest
+        .spyOn(leagueServiceMock, "getRosterDiscordIds")
+        .mockResolvedValueOnce(
+          new Map([
+            ["alpha1", "Alpha"],
+            ["beta1", "Beta"],
+            ["gamma1", "Gamma"],
+          ]),
+        );
+      const team = makeTeam(["alpha1", "beta1", "gamma1"]);
+      await prioService.getTeamPrioForScrim(leagueScrim, [team], []);
+      expect(team.prio).toEqual({
+        amount: 2,
+        reasons:
+          "all 3 players from different league teams: Alpha, Beta, Gamma",
+      });
+    });
+
+    it("should assign tier 1 when fewer than 2 on same league team", async () => {
+      jest
+        .spyOn(leagueServiceMock, "getRosterDiscordIds")
+        .mockResolvedValueOnce(
+          new Map([
+            ["alpha1", "Alpha"],
+            ["beta1", "Beta"],
+          ]),
+        );
+      const team = makeTeam(["alpha1", "beta1", "outsider"]);
+      await prioService.getTeamPrioForScrim(leagueScrim, [team], []);
+      expect(team.prio).toEqual({
+        amount: 1,
+        reasons: "fewer than 2 players from same league team",
       });
     });
   });
@@ -211,6 +332,22 @@ describe("Prio", () => {
             },
           },
         ]);
+      });
+
+      it("should not set prio when scrim type is tournament", async () => {
+        const tournamentScrim: Scrim = {
+          scrimType: ScrimType.tournament,
+          dateTime: new Date(),
+        } as Scrim;
+        const team: ScrimSignup = {
+          date: new Date(),
+          players: [],
+          signupId: "",
+          signupPlayer: { id: "", discordId: "", displayName: "" },
+          teamName: "",
+        };
+        await prioService.getTeamPrioForScrim(tournamentScrim, [team], []);
+        expect(team.prio).toBeUndefined();
       });
 
       it("should set high prio for teams from its players", async () => {

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -22,8 +22,6 @@ import { BanService } from "../../src/services/ban";
 import { BanServiceMock } from "../mocks/ban.mock";
 import { ScrimServiceMock } from "../mocks/scrim-service.mock";
 import { ScrimService } from "../../src/services/scrim-service";
-import { LeagueServiceMock } from "../mocks/league.mock";
-import { LeagueService } from "../../src/services/league";
 
 jest.mock("../../src/config", () => {
   return {
@@ -40,7 +38,6 @@ describe("Signups", () => {
   let authServiceMock: AuthMock;
   let mockBanService: BanService;
   let scrimServiceMock: ScrimServiceMock;
-  let leagueServiceMock: LeagueServiceMock;
   const correctDiscordChannelId = "a forum post";
   const correctScrimId = "32451";
 
@@ -53,7 +50,6 @@ describe("Signups", () => {
 
     authServiceMock = new AuthMock();
     scrimServiceMock = new ScrimServiceMock();
-    leagueServiceMock = new LeagueServiceMock();
     signups = new SignupService(
       dbMock,
       prioServiceMock as PrioService,
@@ -61,7 +57,6 @@ describe("Signups", () => {
       new DiscordServiceMock() as DiscordService,
       mockBanService,
       scrimServiceMock as unknown as ScrimService,
-      leagueServiceMock as unknown as LeagueService,
     );
     insertPlayersSpy = jest.spyOn(dbMock, "insertPlayers");
     insertPlayersSpy.mockReturnValue(
@@ -571,22 +566,9 @@ describe("Signups", () => {
 
       jest
         .spyOn(prioServiceMock, "getTeamPrioForScrim")
-        .mockImplementation((_, teams: ScrimSignup[]) => {
-          for (const team of teams) {
-            switch (team.teamName) {
-              case highPrioTeam.team_name:
-                team.prio = { amount: 1, reasons: "High prio" };
-                break;
-              case mediumPrioTeam.team_name:
-                team.prio = { amount: 0, reasons: "" };
-                break;
-              case lowPrioTeam.team_name:
-                team.prio = { amount: -1, reasons: "Low prio" };
-                break;
-            }
-          }
-          return Promise.resolve(teams);
-        });
+        .mockImplementation((_, teams: ScrimSignup[]) =>
+          Promise.resolve(teams),
+        );
       jest
         .spyOn(dbMock, "getScrimSignupsWithPlayers")
         .mockReturnValue(
@@ -602,189 +584,6 @@ describe("Signups", () => {
         "Medium Prio",
         "High Prio",
       ]);
-    });
-
-    describe("League prio type", () => {
-      const leagueScrim = {
-        id: correctScrimId,
-        dateTime: new Date("2026-01-01T20:00:00"),
-        discordChannel: correctDiscordChannelId,
-        active: false,
-        scrimType: ScrimType.league,
-      };
-
-      beforeEach(() => {
-        jest
-          .spyOn(scrimServiceMock, "getScrim")
-          .mockReturnValue(Promise.resolve(leagueScrim));
-        jest
-          .spyOn(prioServiceMock, "getTeamPrioForScrim")
-          .mockImplementation((_, teams: ScrimSignup[]) =>
-            Promise.resolve(teams),
-          );
-      });
-
-      const makeTeam = (
-        teamName: string,
-        dateTime: string,
-        discordIds: [string, string, string],
-      ): ScrimSignupsWithPlayers =>
-        ({
-          date_time: dateTime,
-          team_name: teamName,
-          player_one_discord_id: discordIds[0],
-          player_two_discord_id: discordIds[1],
-          player_three_discord_id: discordIds[2],
-        }) as ScrimSignupsWithPlayers;
-
-      it("Should sort by league tier then signup date", async () => {
-        // Tier 1: all 3 on same league team
-        const tier1Team = makeTeam("Tier1", "2024-10-28T20:00:00.000+00:00", [
-          "alpha1",
-          "alpha2",
-          "alpha3",
-        ]);
-        // Tier 2: 2 on same league team, 3rd on a different league team
-        const tier2Team = makeTeam("Tier2", "2024-10-10T20:00:00.000+00:00", [
-          "alpha1",
-          "alpha2",
-          "beta1",
-        ]);
-        // Tier 3: 2 on same league team, 3rd not in league
-        const tier3Team = makeTeam("Tier3", "2024-10-13T20:00:00.000+00:00", [
-          "alpha1",
-          "alpha2",
-          "outsider",
-        ]);
-        // Tier 4: all 3 on different league teams
-        const tier4Team = makeTeam("Tier4", "2024-10-14T20:00:00.000+00:00", [
-          "alpha1",
-          "beta1",
-          "gamma1",
-        ]);
-        // Tier 5: fewer than 2 on same league team, not all in league
-        const tier5Team = makeTeam("Tier5", "2024-10-15T20:00:00.000+00:00", [
-          "alpha1",
-          "beta1",
-          "outsider",
-        ]);
-
-        const rosterMap = new Map([
-          ["alpha1", "Alpha"],
-          ["alpha2", "Alpha"],
-          ["alpha3", "Alpha"],
-          ["beta1", "Beta"],
-          ["beta2", "Beta"],
-          ["beta3", "Beta"],
-          ["gamma1", "Gamma"],
-          ["gamma2", "Gamma"],
-          ["gamma3", "Gamma"],
-        ]);
-        jest
-          .spyOn(leagueServiceMock, "getRosterDiscordIds")
-          .mockResolvedValueOnce(rosterMap);
-        jest
-          .spyOn(dbMock, "getScrimSignupsWithPlayers")
-          .mockReturnValue(
-            Promise.resolve([
-              tier5Team,
-              tier4Team,
-              tier2Team,
-              tier1Team,
-              tier3Team,
-            ]),
-          );
-
-        const { mainList, waitList } = await signups.getSignups(
-          correctDiscordChannelId,
-        );
-        const allTeams = [...mainList, ...waitList];
-        expect(allTeams.map((t) => t.teamName)).toEqual([
-          "Tier1",
-          "Tier2",
-          "Tier3",
-          "Tier4",
-          "Tier5",
-        ]);
-        expect(allTeams.map((t) => t.prio)).toEqual([
-          { amount: 5, reasons: "3/3 players from same league team" },
-          {
-            amount: 4,
-            reasons:
-              "2/3 players from same league team, 1 from different league team",
-          },
-          {
-            amount: 3,
-            reasons: "2/3 players from same league team, 1 not in league",
-          },
-          { amount: 2, reasons: "all 3 players from different league teams" },
-          {
-            amount: 1,
-            reasons: "fewer than 2 players from same league team",
-          },
-        ]);
-      });
-
-      it("Should use signup date as tiebreaker within the same tier", async () => {
-        const earlyTier1 = makeTeam(
-          "Early Tier1",
-          "2024-10-10T20:00:00.000+00:00",
-          ["alpha1", "alpha2", "alpha3"],
-        );
-        const lateTier1 = makeTeam(
-          "Late Tier1",
-          "2024-10-28T20:00:00.000+00:00",
-          ["beta1", "beta2", "beta3"],
-        );
-
-        const rosterMap = new Map([
-          ["alpha1", "Alpha"],
-          ["alpha2", "Alpha"],
-          ["alpha3", "Alpha"],
-          ["beta1", "Beta"],
-          ["beta2", "Beta"],
-          ["beta3", "Beta"],
-        ]);
-        jest
-          .spyOn(leagueServiceMock, "getRosterDiscordIds")
-          .mockResolvedValueOnce(rosterMap);
-        jest
-          .spyOn(dbMock, "getScrimSignupsWithPlayers")
-          .mockReturnValue(Promise.resolve([lateTier1, earlyTier1]));
-
-        const { mainList, waitList } = await signups.getSignups(
-          correctDiscordChannelId,
-        );
-        const allTeams = [...mainList, ...waitList];
-        expect(allTeams.map((t) => t.teamName)).toEqual([
-          "Early Tier1",
-          "Late Tier1",
-        ]);
-      });
-
-      it("Should sort by date only when roster map is empty", async () => {
-        const laterTeam: ScrimSignupsWithPlayers = {
-          date_time: "2024-10-28T20:10:35.706+00:00",
-          team_name: "Later",
-        } as ScrimSignupsWithPlayers;
-        const earlierTeam: ScrimSignupsWithPlayers = {
-          date_time: "2024-10-10T20:10:35.706+00:00",
-          team_name: "Earlier",
-        } as ScrimSignupsWithPlayers;
-
-        jest
-          .spyOn(leagueServiceMock, "getRosterDiscordIds")
-          .mockResolvedValueOnce(new Map());
-        jest
-          .spyOn(dbMock, "getScrimSignupsWithPlayers")
-          .mockReturnValue(Promise.resolve([laterTeam, earlierTeam]));
-
-        const { mainList, waitList } = await signups.getSignups(
-          correctDiscordChannelId,
-        );
-        const allTeams = [...mainList, ...waitList];
-        expect(allTeams.map((t) => t.teamName)).toEqual(["Earlier", "Later"]);
-      });
     });
 
     it("Should throw error when no scrim", async () => {

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -22,6 +22,8 @@ import { BanService } from "../../src/services/ban";
 import { BanServiceMock } from "../mocks/ban.mock";
 import { ScrimServiceMock } from "../mocks/scrim-service.mock";
 import { ScrimService } from "../../src/services/scrim-service";
+import { LeagueServiceMock } from "../mocks/league.mock";
+import { LeagueService } from "../../src/services/league";
 
 jest.mock("../../src/config", () => {
   return {
@@ -38,6 +40,7 @@ describe("Signups", () => {
   let authServiceMock: AuthMock;
   let mockBanService: BanService;
   let scrimServiceMock: ScrimServiceMock;
+  let leagueServiceMock: LeagueServiceMock;
   const correctDiscordChannelId = "a forum post";
   const correctScrimId = "32451";
 
@@ -50,6 +53,7 @@ describe("Signups", () => {
 
     authServiceMock = new AuthMock();
     scrimServiceMock = new ScrimServiceMock();
+    leagueServiceMock = new LeagueServiceMock();
     signups = new SignupService(
       dbMock,
       prioServiceMock as PrioService,
@@ -57,6 +61,7 @@ describe("Signups", () => {
       new DiscordServiceMock() as DiscordService,
       mockBanService,
       scrimServiceMock as unknown as ScrimService,
+      leagueServiceMock as unknown as LeagueService,
     );
     insertPlayersSpy = jest.spyOn(dbMock, "insertPlayers");
     insertPlayersSpy.mockReturnValue(
@@ -599,63 +604,154 @@ describe("Signups", () => {
       ]);
     });
 
-    it("Should sort teams by signup date only when prio type is league", async () => {
-      jest.spyOn(scrimServiceMock, "getScrim").mockReturnValueOnce(
-        Promise.resolve({
-          id: correctScrimId,
-          dateTime: new Date("2026-01-01T20:00:00"),
-          discordChannel: correctDiscordChannelId,
-          active: false,
-          prioType: PrioType.league,
-        }),
-      );
+    describe("League prio type", () => {
+      const leagueScrim = {
+        id: correctScrimId,
+        dateTime: new Date("2026-01-01T20:00:00"),
+        discordChannel: correctDiscordChannelId,
+        active: false,
+        prioType: PrioType.league,
+      };
 
-      const highPrioTeam: ScrimSignupsWithPlayers = {
-        date_time: "2024-10-28T20:10:35.706+00:00",
-        team_name: "High Prio",
-      } as ScrimSignupsWithPlayers;
-      const lowPrioTeam: ScrimSignupsWithPlayers = {
-        date_time: "2024-10-10T20:10:35.706+00:00",
-        team_name: "Low Prio",
-      } as ScrimSignupsWithPlayers;
-      const mediumPrioTeam: ScrimSignupsWithPlayers = {
-        date_time: "2024-10-13T20:10:35.706+00:00",
-        team_name: "Medium Prio",
-      } as ScrimSignupsWithPlayers;
+      beforeEach(() => {
+        jest
+          .spyOn(scrimServiceMock, "getScrim")
+          .mockReturnValue(Promise.resolve(leagueScrim));
+        jest
+          .spyOn(prioServiceMock, "getTeamPrioForScrim")
+          .mockImplementation((_, teams: ScrimSignup[]) =>
+            Promise.resolve(teams),
+          );
+      });
 
-      jest
-        .spyOn(prioServiceMock, "getTeamPrioForScrim")
-        .mockImplementation((_, teams: ScrimSignup[]) => {
-          for (const team of teams) {
-            switch (team.teamName) {
-              case highPrioTeam.team_name:
-                team.prio = { amount: 1, reasons: "High prio" };
-                break;
-              case mediumPrioTeam.team_name:
-                team.prio = { amount: 0, reasons: "" };
-                break;
-              case lowPrioTeam.team_name:
-                team.prio = { amount: -1, reasons: "Low prio" };
-                break;
-            }
-          }
-          return Promise.resolve(teams);
-        });
-      jest
-        .spyOn(dbMock, "getScrimSignupsWithPlayers")
-        .mockReturnValue(
-          Promise.resolve([highPrioTeam, mediumPrioTeam, lowPrioTeam]),
+      const makeTeam = (
+        teamName: string,
+        dateTime: string,
+        discordIds: [string, string, string],
+      ): ScrimSignupsWithPlayers =>
+        ({
+          date_time: dateTime,
+          team_name: teamName,
+          player_one_discord_id: discordIds[0],
+          player_two_discord_id: discordIds[1],
+          player_three_discord_id: discordIds[2],
+        }) as ScrimSignupsWithPlayers;
+
+      it("Should sort by league tier then signup date", async () => {
+        // Tier 1: all 3 on same league team
+        const tier1Team = makeTeam("Tier1", "2024-10-28T20:00:00.000+00:00", [
+          "alpha1",
+          "alpha2",
+          "alpha3",
+        ]);
+        // Tier 2: 2 on same league team, 3rd on a different league team
+        const tier2Team = makeTeam("Tier2", "2024-10-10T20:00:00.000+00:00", [
+          "alpha1",
+          "alpha2",
+          "beta1",
+        ]);
+        // Tier 3: 2 on same league team, 3rd not in league
+        const tier3Team = makeTeam("Tier3", "2024-10-13T20:00:00.000+00:00", [
+          "alpha1",
+          "alpha2",
+          "outsider",
+        ]);
+        // Tier 4: fewer than 2 on same league team
+        const tier4Team = makeTeam("Tier4", "2024-10-14T20:00:00.000+00:00", [
+          "alpha1",
+          "beta1",
+          "outsider",
+        ]);
+
+        const rosterMap = new Map([
+          ["alpha1", "Alpha"],
+          ["alpha2", "Alpha"],
+          ["alpha3", "Alpha"],
+          ["beta1", "Beta"],
+          ["beta2", "Beta"],
+          ["beta3", "Beta"],
+        ]);
+        jest
+          .spyOn(leagueServiceMock, "getRosterDiscordIds")
+          .mockResolvedValueOnce(rosterMap);
+        jest
+          .spyOn(dbMock, "getScrimSignupsWithPlayers")
+          .mockReturnValue(
+            Promise.resolve([tier4Team, tier2Team, tier1Team, tier3Team]),
+          );
+
+        const { mainList, waitList } = await signups.getSignups(
+          correctDiscordChannelId,
+        );
+        const allTeams = [...mainList, ...waitList];
+        expect(allTeams.map((t) => t.teamName)).toEqual([
+          "Tier1",
+          "Tier2",
+          "Tier3",
+          "Tier4",
+        ]);
+      });
+
+      it("Should use signup date as tiebreaker within the same tier", async () => {
+        const earlyTier1 = makeTeam(
+          "Early Tier1",
+          "2024-10-10T20:00:00.000+00:00",
+          ["alpha1", "alpha2", "alpha3"],
+        );
+        const lateTier1 = makeTeam(
+          "Late Tier1",
+          "2024-10-28T20:00:00.000+00:00",
+          ["beta1", "beta2", "beta3"],
         );
 
-      const { mainList, waitList } = await signups.getSignups(
-        correctDiscordChannelId,
-      );
-      const allTeams = [...mainList, ...waitList];
-      expect(allTeams.map((t) => t.teamName)).toEqual([
-        "Low Prio",
-        "Medium Prio",
-        "High Prio",
-      ]);
+        const rosterMap = new Map([
+          ["alpha1", "Alpha"],
+          ["alpha2", "Alpha"],
+          ["alpha3", "Alpha"],
+          ["beta1", "Beta"],
+          ["beta2", "Beta"],
+          ["beta3", "Beta"],
+        ]);
+        jest
+          .spyOn(leagueServiceMock, "getRosterDiscordIds")
+          .mockResolvedValueOnce(rosterMap);
+        jest
+          .spyOn(dbMock, "getScrimSignupsWithPlayers")
+          .mockReturnValue(Promise.resolve([lateTier1, earlyTier1]));
+
+        const { mainList, waitList } = await signups.getSignups(
+          correctDiscordChannelId,
+        );
+        const allTeams = [...mainList, ...waitList];
+        expect(allTeams.map((t) => t.teamName)).toEqual([
+          "Early Tier1",
+          "Late Tier1",
+        ]);
+      });
+
+      it("Should sort by date only when roster map is empty", async () => {
+        const laterTeam: ScrimSignupsWithPlayers = {
+          date_time: "2024-10-28T20:10:35.706+00:00",
+          team_name: "Later",
+        } as ScrimSignupsWithPlayers;
+        const earlierTeam: ScrimSignupsWithPlayers = {
+          date_time: "2024-10-10T20:10:35.706+00:00",
+          team_name: "Earlier",
+        } as ScrimSignupsWithPlayers;
+
+        jest
+          .spyOn(leagueServiceMock, "getRosterDiscordIds")
+          .mockResolvedValueOnce(new Map());
+        jest
+          .spyOn(dbMock, "getScrimSignupsWithPlayers")
+          .mockReturnValue(Promise.resolve([laterTeam, earlierTeam]));
+
+        const { mainList, waitList } = await signups.getSignups(
+          correctDiscordChannelId,
+        );
+        const allTeams = [...mainList, ...waitList];
+        expect(allTeams.map((t) => t.teamName)).toEqual(["Earlier", "Later"]);
+      });
     });
 
     it("Should throw error when no scrim", async () => {

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -706,6 +706,23 @@ describe("Signups", () => {
           "Tier4",
           "Tier5",
         ]);
+        expect(allTeams.map((t) => t.prio)).toEqual([
+          { amount: 5, reasons: "3/3 players from same league team" },
+          {
+            amount: 4,
+            reasons:
+              "2/3 players from same league team, 1 from different league team",
+          },
+          {
+            amount: 3,
+            reasons: "2/3 players from same league team, 1 not in league",
+          },
+          { amount: 2, reasons: "all 3 players from different league teams" },
+          {
+            amount: 1,
+            reasons: "fewer than 2 players from same league team",
+          },
+        ]);
       });
 
       it("Should use signup date as tiebreaker within the same tier", async () => {

--- a/test/services/signups.test.ts
+++ b/test/services/signups.test.ts
@@ -656,8 +656,14 @@ describe("Signups", () => {
           "alpha2",
           "outsider",
         ]);
-        // Tier 4: fewer than 2 on same league team
+        // Tier 4: all 3 on different league teams
         const tier4Team = makeTeam("Tier4", "2024-10-14T20:00:00.000+00:00", [
+          "alpha1",
+          "beta1",
+          "gamma1",
+        ]);
+        // Tier 5: fewer than 2 on same league team, not all in league
+        const tier5Team = makeTeam("Tier5", "2024-10-15T20:00:00.000+00:00", [
           "alpha1",
           "beta1",
           "outsider",
@@ -670,6 +676,9 @@ describe("Signups", () => {
           ["beta1", "Beta"],
           ["beta2", "Beta"],
           ["beta3", "Beta"],
+          ["gamma1", "Gamma"],
+          ["gamma2", "Gamma"],
+          ["gamma3", "Gamma"],
         ]);
         jest
           .spyOn(leagueServiceMock, "getRosterDiscordIds")
@@ -677,7 +686,13 @@ describe("Signups", () => {
         jest
           .spyOn(dbMock, "getScrimSignupsWithPlayers")
           .mockReturnValue(
-            Promise.resolve([tier4Team, tier2Team, tier1Team, tier3Team]),
+            Promise.resolve([
+              tier5Team,
+              tier4Team,
+              tier2Team,
+              tier1Team,
+              tier3Team,
+            ]),
           );
 
         const { mainList, waitList } = await signups.getSignups(
@@ -689,6 +704,7 @@ describe("Signups", () => {
           "Tier2",
           "Tier3",
           "Tier4",
+          "Tier5",
         ]);
       });
 


### PR DESCRIPTION
* Sort league prio scrim teams with new sorting rules
* Use new roster sheet key to get roster information
* updateScrimCount and addTeam now fetches raw signups instead of erroneously requesting sorted signups
* Add priority column to /get-signups csv's
* fix mmr sort including priority when it should just be looking at mmr
* Add document detailing how to potentially mitigate migration changes when moving from sheets signups to db signups