### PR TITLE
task/sub-request-improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrim-bot",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrim-bot",
-      "version": "1.18.1",
+      "version": "1.18.2",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@googleapis/sheets": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "scrim-bot",
   "description": "A multipurpose bot to track scrim signups, low prio and player performance among other things",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "author": "Jacob Heuman",
   "license": "LGPL-3.0-only",
   "scripts": {

--- a/src/commands/league/roster-change.ts
+++ b/src/commands/league/roster-change.ts
@@ -187,7 +187,7 @@ export class RosterChangeCommand extends MemberCommand {
       }
       if (!playerInOverstat) {
         await interaction.followUp(
-          `<@${requestedByMember.id}> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429`,
+          `<@${requestedByMember.id}> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429. You'll need to provide screenshots of the entire screen showing their ranked stats from the last two seasons in the ticket.`,
         );
       }
     } catch (e) {

--- a/src/commands/league/roster-change.ts
+++ b/src/commands/league/roster-change.ts
@@ -170,7 +170,6 @@ export class RosterChangeCommand extends MemberCommand {
         await interaction.followUp(
           `Problem parsing google sheets response, please check sheet to see if your roster change went through before resubmitting\n<${rosterResult.sheetUrl}>`,
         );
-        return;
       } else {
         const subApprovalRoleId =
           await this.staticValueService.getSubApprovalRoleId();

--- a/src/commands/league/roster-change.ts
+++ b/src/commands/league/roster-change.ts
@@ -171,18 +171,26 @@ export class RosterChangeCommand extends MemberCommand {
           `Problem parsing google sheets response, please check sheet to see if your roster change went through before resubmitting\n<${rosterResult.sheetUrl}>`,
         );
         return;
+      } else {
+        const subApprovalRoleId =
+          await this.staticValueService.getSubApprovalRoleId();
+        const roleMention = subApprovalRoleId
+          ? `\n<@&${subApprovalRoleId}>`
+          : "";
+        const playerOutOverstatText = playerOutOverstat
+          ? ` [Overstat](<${playerOutOverstat}>)`
+          : "";
+        const playerInOverstatText = playerInOverstat
+          ? ` [Overstat](<${playerInOverstat}>)`
+          : "";
+        const discordReplyMessage = `Roster change requested for __${teamName}__ (${VesaDivision[teamDivision]})\nRemoving <@${playerOut.id}>${playerOutOverstatText}\nAdding <@${playerIn.id}>${playerInOverstatText}\n[Sheet row #${rosterResult.rowNumber}](<${rosterResult.sheetUrl}>)\nNavigate to the "${rosterResult.tabName}" tab at the bottom of the sheet${roleMention}`;
+        await interaction.followUp(discordReplyMessage);
       }
-      const subApprovalRoleId =
-        await this.staticValueService.getSubApprovalRoleId();
-      const roleMention = subApprovalRoleId ? `\n<@&${subApprovalRoleId}>` : "";
-      const playerOutOverstatText = playerOutOverstat
-        ? ` [Overstat](<${playerOutOverstat}>)`
-        : "";
-      const playerInOverstatText = playerInOverstat
-        ? ` [Overstat](<${playerInOverstat}>)`
-        : "";
-      const discordReplyMessage = `Roster change requested for __${teamName}__ (${VesaDivision[teamDivision]})\nRemoving <@${playerOut.id}>${playerOutOverstatText}\nAdding <@${playerIn.id}>${playerInOverstatText}\n[Sheet row #${rosterResult.rowNumber}](<${rosterResult.sheetUrl}>)\nNavigate to the "${rosterResult.tabName}" tab at the bottom of the sheet${roleMention}`;
-      await interaction.followUp(discordReplyMessage);
+      if (!playerInOverstat) {
+        await interaction.followUp(
+          `<@${requestedByMember.id}> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429`,
+        );
+      }
     } catch (e) {
       await interaction.followUp(`Roster change not made. ${e}`);
     }

--- a/src/commands/league/sub-request.ts
+++ b/src/commands/league/sub-request.ts
@@ -111,6 +111,17 @@ export class LeagueSubRequestCommand extends MemberCommand {
       VesaDivision,
       true,
     );
+
+    if (
+      playerInDivision !== VesaDivision.None &&
+      playerInDivision < teamDivision
+    ) {
+      await interaction.invisibleReply(
+        `Sub request not made. The player subbing in is in ${VesaDivision[playerInDivision]} which is a higher division than the team's division (${VesaDivision[teamDivision]}).`,
+      );
+      return;
+    }
+
     const requestedByMember = interaction.member;
     const playerOut = interaction.options.getUser(
       this.inputNames.playerOutInputNames.user,

--- a/src/commands/league/sub-request.ts
+++ b/src/commands/league/sub-request.ts
@@ -225,7 +225,6 @@ export class LeagueSubRequestCommand extends MemberCommand {
         await interaction.followUp(
           `Problem parsing google sheets response, please check sheet to see if your sub request went through before resubmitting\n<${subResult.sheetUrl}>`,
         );
-        return;
       } else {
         const discordReplyMessage = `Sub requested for __${teamName}__ (${VesaDivision[teamDivision]})\nSubbing out <@${playerOut.id}>${playerOutOverstatText}\nSubbing in <@${playerIn.id}>${playerInOverstatText}\nRequested week: ${WeekNumbers[weekNumber]}\n[Sheet row #${subResult.rowNumber}](<${subResult.sheetUrl}>)\nNavigate to the "${subResult.tabName}" tab at the bottom of the sheet${roleMention}`;
         await interaction.followUp(discordReplyMessage);

--- a/src/commands/league/sub-request.ts
+++ b/src/commands/league/sub-request.ts
@@ -226,9 +226,15 @@ export class LeagueSubRequestCommand extends MemberCommand {
           `Problem parsing google sheets response, please check sheet to see if your sub request went through before resubmitting\n<${subResult.sheetUrl}>`,
         );
         return;
+      } else {
+        const discordReplyMessage = `Sub requested for __${teamName}__ (${VesaDivision[teamDivision]})\nSubbing out <@${playerOut.id}>${playerOutOverstatText}\nSubbing in <@${playerIn.id}>${playerInOverstatText}\nRequested week: ${WeekNumbers[weekNumber]}\n[Sheet row #${subResult.rowNumber}](<${subResult.sheetUrl}>)\nNavigate to the "${subResult.tabName}" tab at the bottom of the sheet${roleMention}`;
+        await interaction.followUp(discordReplyMessage);
       }
-      const discordReplyMessage = `Sub requested for __${teamName}__ (${VesaDivision[teamDivision]})\nSubbing out <@${playerOut.id}>${playerOutOverstatText}\nSubbing in <@${playerIn.id}>${playerInOverstatText}\nRequested week: ${WeekNumbers[weekNumber]}\n[Sheet row #${subResult.rowNumber}](<${subResult.sheetUrl}>)\nNavigate to the "${subResult.tabName}" tab at the bottom of the sheet${roleMention}`;
-      await interaction.followUp(discordReplyMessage);
+      if (!playerInOverstat) {
+        await interaction.followUp(
+          `<@${requestedByMember.id}> No overstat provided for the player subbing in, please reply to this message with screenshots of the entire screen showing their ranked stats from the last two seasons in this channel.`,
+        );
+      }
     } catch (e) {
       await interaction.followUp(`Sub request not made. ${e}`);
     }

--- a/test/commands/league/roster-change.test.ts
+++ b/test/commands/league/roster-change.test.ts
@@ -217,6 +217,44 @@ describe("Roster change", () => {
     );
   });
 
+  it("should post no-overstat instructions even when response can't be parsed", async () => {
+    const noOverstatInteraction = {
+      ...basicInteraction,
+      options: {
+        ...(basicInteraction.options as object),
+        getString: (key: string) => {
+          if (
+            key ===
+            staticCommandUsedJustForInputNames.inputNames.playerInInputNames
+              .overstatLink
+          ) {
+            return "None";
+          }
+          return (
+            basicInteraction.options as unknown as {
+              getString: (key: string) => string | null;
+            }
+          ).getString(key);
+        },
+      },
+    } as unknown as CustomInteraction;
+
+    rosterChangeSpy.mockResolvedValueOnce({
+      rowNumber: null,
+      sheetUrl: "https://docs.google.com/spreadsheets/d/mock_roster_sheet_id",
+      tabName: "mock_roster_tab_name",
+    });
+    getPlayerOverstatSpy
+      .mockResolvedValueOnce(overstats.player1)
+      .mockRejectedValueOnce(new Error("not in db"));
+
+    await command.run(noOverstatInteraction);
+    expect(followUpSpy).toHaveBeenCalledTimes(2);
+    expect(followUpSpy).toHaveBeenLastCalledWith(
+      `<@player1id> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429`,
+    );
+  });
+
   describe("player-out overstat provided directly", () => {
     let interactionWithPlayerOutOverstat: CustomInteraction;
 

--- a/test/commands/league/roster-change.test.ts
+++ b/test/commands/league/roster-change.test.ts
@@ -172,6 +172,39 @@ describe("Roster change", () => {
     );
   });
 
+  it("should post no-overstat instructions when player-in has no overstat", async () => {
+    const noOverstatInteraction = {
+      ...basicInteraction,
+      options: {
+        ...(basicInteraction.options as object),
+        getString: (key: string) => {
+          if (
+            key ===
+            staticCommandUsedJustForInputNames.inputNames.playerInInputNames
+              .overstatLink
+          ) {
+            return "None";
+          }
+          return (
+            basicInteraction.options as unknown as {
+              getString: (key: string) => string | null;
+            }
+          ).getString(key);
+        },
+      },
+    } as unknown as CustomInteraction;
+
+    getPlayerOverstatSpy
+      .mockResolvedValueOnce(overstats.player1)
+      .mockRejectedValueOnce(new Error("not in db"));
+
+    await command.run(noOverstatInteraction);
+    expect(followUpSpy).toHaveBeenCalledTimes(2);
+    expect(followUpSpy).toHaveBeenLastCalledWith(
+      `<@player1id> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429`,
+    );
+  });
+
   it("Should complete request but warn that response can't be parsed", async () => {
     rosterChangeSpy.mockResolvedValueOnce({
       rowNumber: null,

--- a/test/commands/league/roster-change.test.ts
+++ b/test/commands/league/roster-change.test.ts
@@ -201,7 +201,7 @@ describe("Roster change", () => {
     await command.run(noOverstatInteraction);
     expect(followUpSpy).toHaveBeenCalledTimes(2);
     expect(followUpSpy).toHaveBeenLastCalledWith(
-      `<@player1id> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429`,
+      `<@player1id> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429. You'll need to provide screenshots of the entire screen showing their ranked stats from the last two seasons in the ticket.`,
     );
   });
 
@@ -251,7 +251,7 @@ describe("Roster change", () => {
     await command.run(noOverstatInteraction);
     expect(followUpSpy).toHaveBeenCalledTimes(2);
     expect(followUpSpy).toHaveBeenLastCalledWith(
-      `<@player1id> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429`,
+      `<@player1id> No overstat provided for the player being added, create a ticket to finalize this change https://discord.com/channels/1292412338749837383/1354736726748172429. You'll need to provide screenshots of the entire screen showing their ranked stats from the last two seasons in the ticket.`,
     );
   });
 

--- a/test/commands/league/sub-request.test.ts
+++ b/test/commands/league/sub-request.test.ts
@@ -302,6 +302,63 @@ describe("Sub request", () => {
   });
 
   describe("errors", () => {
+    it("should complete because player-in is in a lower division than the team", async () => {
+      const lowerDivInteraction = {
+        ...basicInteraction,
+        options: {
+          ...(basicInteraction.options as object),
+          getChoice: (key: string) => {
+            if (
+              key ===
+              staticCommandUsedJustForInputNames.inputNames.playerInInputNames
+                .division
+            ) {
+              return 6; // Division6, lower than team's Division4
+            }
+            return (
+              basicInteraction.options as unknown as {
+                getChoice: (key: string) => number | null;
+              }
+            ).getChoice(key);
+          },
+        },
+      } as unknown as CustomInteraction;
+      await command.run(lowerDivInteraction);
+      expect(subRequestSpy).toHaveBeenCalled();
+    });
+
+    it("should not complete because player-in is in a higher division than the team", async () => {
+      const higherDivInteraction = {
+        ...basicInteraction,
+        options: {
+          ...(basicInteraction.options as object),
+          getChoice: (key: string) => {
+            if (
+              key ===
+              staticCommandUsedJustForInputNames.inputNames.playerInInputNames
+                .division
+            ) {
+              return 2; // Division2, higher than team's Division4
+            }
+            return (
+              basicInteraction.options as unknown as {
+                getChoice: (key: string) => number | null;
+              }
+            ).getChoice(key);
+          },
+        },
+      } as unknown as CustomInteraction;
+      const higherDivInvisibleReplySpy = jest.spyOn(
+        higherDivInteraction,
+        "invisibleReply",
+      );
+      await command.run(higherDivInteraction);
+      expect(higherDivInvisibleReplySpy).toHaveBeenCalledWith(
+        `Sub request not made. The player subbing in is in Division2 which is a higher division than the team's division (Division4).`,
+      );
+      expect(subRequestSpy).not.toHaveBeenCalled();
+    });
+
     it("should not complete the signup because google did a bad", async () => {
       subRequestSpy.mockRejectedValueOnce(new Error("Sheets Failure"));
       await command.run(basicInteraction);

--- a/test/commands/league/sub-request.test.ts
+++ b/test/commands/league/sub-request.test.ts
@@ -184,6 +184,39 @@ describe("Sub request", () => {
     );
   });
 
+  it("should post no-overstat instructions when player-in has no overstat", async () => {
+    const noOverstatInteraction = {
+      ...basicInteraction,
+      options: {
+        ...(basicInteraction.options as object),
+        getString: (key: string) => {
+          if (
+            key ===
+            staticCommandUsedJustForInputNames.inputNames.playerInInputNames
+              .overstatLink
+          ) {
+            return "None";
+          }
+          return (
+            basicInteraction.options as unknown as {
+              getString: (key: string) => string | null;
+            }
+          ).getString(key);
+        },
+      },
+    } as unknown as CustomInteraction;
+
+    getPlayerOverstatSpy
+      .mockResolvedValueOnce(overstats.player1)
+      .mockRejectedValueOnce(new Error("not in db"));
+
+    await command.run(noOverstatInteraction);
+    expect(followUpSpy).toHaveBeenCalledTimes(2);
+    expect(followUpSpy).toHaveBeenLastCalledWith(
+      `<@player1id> No overstat provided for the player subbing in, please reply to this message with screenshots of the entire screen showing their ranked stats from the last two seasons in this channel.`,
+    );
+  });
+
   it("Should complete signup but warn that response can't be parsed", async () => {
     subRequestSpy.mockResolvedValueOnce({
       rowNumber: null,

--- a/test/commands/league/sub-request.test.ts
+++ b/test/commands/league/sub-request.test.ts
@@ -229,6 +229,44 @@ describe("Sub request", () => {
     );
   });
 
+  it("should post no-overstat instructions even when response can't be parsed", async () => {
+    const noOverstatInteraction = {
+      ...basicInteraction,
+      options: {
+        ...(basicInteraction.options as object),
+        getString: (key: string) => {
+          if (
+            key ===
+            staticCommandUsedJustForInputNames.inputNames.playerInInputNames
+              .overstatLink
+          ) {
+            return "None";
+          }
+          return (
+            basicInteraction.options as unknown as {
+              getString: (key: string) => string | null;
+            }
+          ).getString(key);
+        },
+      },
+    } as unknown as CustomInteraction;
+
+    subRequestSpy.mockResolvedValueOnce({
+      rowNumber: null,
+      sheetUrl: "https://docs.google.com/spreadsheets/d/mock_sub_sheet_id",
+      tabName: "mock_sub_tab_name",
+    });
+    getPlayerOverstatSpy
+      .mockResolvedValueOnce(overstats.player1)
+      .mockRejectedValueOnce(new Error("not in db"));
+
+    await command.run(noOverstatInteraction);
+    expect(followUpSpy).toHaveBeenCalledTimes(2);
+    expect(followUpSpy).toHaveBeenLastCalledWith(
+      `<@player1id> No overstat provided for the player subbing in, please reply to this message with screenshots of the entire screen showing their ranked stats from the last two seasons in this channel.`,
+    );
+  });
+
   describe("player-out overstat provided directly", () => {
     let interactionWithPlayerOutOverstat: CustomInteraction;
 
@@ -334,32 +372,32 @@ describe("Sub request", () => {
     });
   });
 
-  describe("errors", () => {
-    it("should complete because player-in is in a lower division than the team", async () => {
-      const lowerDivInteraction = {
-        ...basicInteraction,
-        options: {
-          ...(basicInteraction.options as object),
-          getChoice: (key: string) => {
-            if (
-              key ===
-              staticCommandUsedJustForInputNames.inputNames.playerInInputNames
-                .division
-            ) {
-              return 6; // Division6, lower than team's Division4
+  it("should complete because player-in is in a lower division than the team", async () => {
+    const lowerDivInteraction = {
+      ...basicInteraction,
+      options: {
+        ...(basicInteraction.options as object),
+        getChoice: (key: string) => {
+          if (
+            key ===
+            staticCommandUsedJustForInputNames.inputNames.playerInInputNames
+              .division
+          ) {
+            return 6; // Division6, lower than team's Division4
+          }
+          return (
+            basicInteraction.options as unknown as {
+              getChoice: (key: string) => number | null;
             }
-            return (
-              basicInteraction.options as unknown as {
-                getChoice: (key: string) => number | null;
-              }
-            ).getChoice(key);
-          },
+          ).getChoice(key);
         },
-      } as unknown as CustomInteraction;
-      await command.run(lowerDivInteraction);
-      expect(subRequestSpy).toHaveBeenCalled();
-    });
+      },
+    } as unknown as CustomInteraction;
+    await command.run(lowerDivInteraction);
+    expect(subRequestSpy).toHaveBeenCalled();
+  });
 
+  describe("errors", () => {
     it("should not complete because player-in is in a higher division than the team", async () => {
       const higherDivInteraction = {
         ...basicInteraction,
@@ -381,12 +419,8 @@ describe("Sub request", () => {
           },
         },
       } as unknown as CustomInteraction;
-      const higherDivInvisibleReplySpy = jest.spyOn(
-        higherDivInteraction,
-        "invisibleReply",
-      );
       await command.run(higherDivInteraction);
-      expect(higherDivInvisibleReplySpy).toHaveBeenCalledWith(
+      expect(invisibleReplySpy).toHaveBeenCalledWith(
         `Sub request not made. The player subbing in is in Division2 which is a higher division than the team's division (Division4).`,
       );
       expect(subRequestSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
 * reject sub requests when the player subbing in is in a higher division than the team
 * public follow-up message when the player being added has no overstat linked for both roster change and sub request commands